### PR TITLE
Refactoring & add snapshot header support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 group=io.github.origin-energy
-version=3.2.6-SNAPSHOT
+version=3.2.5-SNAPSHOT

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Expect.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Expect.java
@@ -8,7 +8,9 @@ import lombok.SneakyThrows;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class Expect {
@@ -19,6 +21,8 @@ public class Expect {
   private SnapshotComparator snapshotComparator;
   private List<SnapshotReporter> snapshotReporters;
   private String scenario;
+
+  private final Map<String, String> headers = new HashMap<>();
 
   public static Expect of(SnapshotVerifier snapshotVerifier, Method method) {
     return new Expect(snapshotVerifier, method);
@@ -31,20 +35,22 @@ public class Expect {
    * @param objects     other snapshot objects
    */
   public void toMatchSnapshot(Object firstObject, Object... objects) {
-    Snapshot snapshot = snapshotVerifier.expectCondition(testMethod, firstObject, objects);
+    SnapshotContext snapshotContext = snapshotVerifier.expectCondition(testMethod, firstObject, objects);
     if (snapshotSerializer != null) {
-      snapshot.setSnapshotSerializer(snapshotSerializer);
+      snapshotContext.setSnapshotSerializer(snapshotSerializer);
     }
     if (snapshotComparator != null) {
-      snapshot.setSnapshotComparator(snapshotComparator);
+      snapshotContext.setSnapshotComparator(snapshotComparator);
     }
     if (snapshotReporters != null) {
-      snapshot.setSnapshotReporters(snapshotReporters);
+      snapshotContext.setSnapshotReporters(snapshotReporters);
     }
     if (scenario != null) {
-      snapshot.setScenario(scenario);
+      snapshotContext.setScenario(scenario);
     }
-    snapshot.toMatchSnapshot();
+    snapshotContext.header.putAll(headers);
+
+    snapshotContext.toMatchSnapshot();
   }
 
 
@@ -96,6 +102,17 @@ public class Expect {
   }
 
   /**
+   * Apply a custom comparator for this snapshot
+   *
+   * @param name the {name} attribute comparator.{name} from snapshot.properties
+   * @return Snapshot
+   */
+  public Expect comparator(String name) {
+    this.snapshotComparator = SnapshotProperties.getInstance("comparator." + name);
+    return this;
+  }
+
+  /**
    * Apply a list of custom reporters for this snapshot
    * This will replace the default reporters defined in the config
    *
@@ -104,6 +121,18 @@ public class Expect {
    */
   public Expect reporters(SnapshotReporter... reporters) {
     this.snapshotReporters = Arrays.asList(reporters);
+    return this;
+  }
+
+  /**
+   * Apply a list of custom reporters for this snapshot
+   * This will replace the default reporters defined in the config
+   *
+   * @param name the {name} attribute reporters.{name} from snapshot.properties
+   * @return Snapshot
+   */
+  public Expect reporters(String name) {
+    this.snapshotReporters = SnapshotProperties.getInstances("reporters." + name);
     return this;
   }
 
@@ -121,6 +150,21 @@ public class Expect {
   @SneakyThrows
   public Expect serializer(Class<? extends SnapshotSerializer> serializer) {
     this.snapshotSerializer = serializer.getConstructor().newInstance();
+    return this;
+  }
+
+  /**
+   * Add anything you like to the snapshot header.
+   *
+   * These custom headers can be used in serializers, comparators or reporters to change
+   * how they behave.
+   *
+   * @param key key
+   * @param value value
+   * @return Expect
+   */
+  public Expect header(String key, String value) {
+    headers.put(key, value);
     return this;
   }
 

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotContext.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotContext.java
@@ -1,0 +1,152 @@
+package au.com.origin.snapshots;
+
+import au.com.origin.snapshots.annotations.SnapshotName;
+import au.com.origin.snapshots.comparators.SnapshotComparator;
+import au.com.origin.snapshots.config.SnapshotConfig;
+import au.com.origin.snapshots.exceptions.SnapshotMatchException;
+import au.com.origin.snapshots.reporters.SnapshotReporter;
+import au.com.origin.snapshots.serializers.SnapshotSerializer;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SnapshotContext {
+
+  private final SnapshotConfig snapshotConfig;
+  private final SnapshotFile snapshotFile;
+
+  @Getter
+  final Class<?> testClass;
+
+  @Getter
+  final Method testMethod;
+
+  final Object[] current;
+  private final boolean isCI;
+
+  @Setter
+  private SnapshotSerializer snapshotSerializer;
+  @Setter
+  private SnapshotComparator snapshotComparator;
+  @Setter
+  private List<SnapshotReporter> snapshotReporters;
+
+  @Setter
+  @Getter
+  String scenario;
+
+  @Getter
+  SnapshotHeader header = new SnapshotHeader();
+
+  SnapshotContext(
+      SnapshotConfig snapshotConfig,
+      SnapshotFile snapshotFile,
+      Class<?> testClass,
+      Method testMethod,
+      Object... current) {
+    this.snapshotConfig = snapshotConfig;
+    this.snapshotFile = snapshotFile;
+    this.testClass = testClass;
+    this.testMethod = testMethod;
+    this.current = current;
+
+    this.isCI = snapshotConfig.isCI();
+    this.snapshotSerializer = snapshotConfig.getSerializer();
+    this.snapshotComparator = snapshotConfig.getComparator();
+    this.snapshotReporters = snapshotConfig.getReporters();
+    this.scenario = null;
+  }
+
+
+  public void toMatchSnapshot() {
+
+    Set<Snapshot> rawSnapshots = snapshotFile.getSnapshots();
+    Snapshot previousSnapshot = getRawSnapshot(rawSnapshots);
+    Snapshot currentSnapshot = takeSnapshot();
+
+    if (previousSnapshot != null && shouldUpdateSnapshot()) {
+      snapshotFile.getSnapshots().remove(previousSnapshot);
+      previousSnapshot = null;
+    }
+
+    if (previousSnapshot != null) {
+      // Match existing Snapshot
+      if (!snapshotComparator.matches(previousSnapshot, currentSnapshot)) {
+        snapshotFile.createDebugFile(currentSnapshot);
+
+        List<SnapshotReporter> reporters = snapshotReporters
+            .stream()
+            .filter(reporter -> reporter.supportsFormat(snapshotSerializer.getOutputFormat()))
+            .collect(Collectors.toList());
+
+        if (reporters.isEmpty()) {
+          String comparator = snapshotComparator.getClass().getSimpleName();
+          throw new IllegalStateException("No compatible reporters found for comparator " + comparator);
+        }
+
+        List<Throwable> errors = new ArrayList<>();
+
+        for (SnapshotReporter reporter : reporters) {
+          try {
+            reporter.report(previousSnapshot, currentSnapshot);
+          } catch (Throwable t) {
+            errors.add(t);
+          }
+        }
+
+        if (!errors.isEmpty()) {
+          throw new SnapshotMatchException("Error(s) matching snapshot(s)", errors);
+        }
+      }
+    } else {
+      if (this.isCI) {
+        log.error("We detected you are running on a CI Server - if this is incorrect please override the isCI() method in SnapshotConfig");
+        throw new SnapshotMatchException("Snapshot [" + resolveSnapshotIdentifier() + "] not found. Has this snapshot been committed ?");
+      } else {
+        log.warn("We detected you are running on a developer machine - if this is incorrect please override the isCI() method in SnapshotConfig");
+        // Create New Snapshot
+        snapshotFile.push(currentSnapshot);
+      }
+    }
+    snapshotFile.deleteDebugFile();
+  }
+
+  private boolean shouldUpdateSnapshot() {
+    if (snapshotConfig.updateSnapshot().isPresent()) {
+      return resolveSnapshotIdentifier().contains(snapshotConfig.updateSnapshot().get());
+    } else {
+      return false;
+    }
+  }
+
+  private Snapshot getRawSnapshot(Collection<Snapshot> rawSnapshots) {
+    for (Snapshot rawSnapshot : rawSnapshots) {
+      if (rawSnapshot.getIdentifier().equals(resolveSnapshotIdentifier())) {
+        return rawSnapshot;
+      }
+    }
+    return null;
+  }
+
+  private Snapshot takeSnapshot() {
+    SnapshotSerializerContext sg = SnapshotSerializerContext.from(this);
+    return snapshotSerializer.apply(current, sg);
+  }
+
+  String resolveSnapshotIdentifier() {
+    String scenarioFormat = scenario == null ? "" : "[" + scenario + "]";
+    SnapshotName snapshotName = testMethod.getAnnotation(SnapshotName.class);
+    String pathFormat = snapshotName == null ?
+        testClass.getName() + "." + testMethod.getName() :
+        snapshotName.value();
+    return pathFormat + scenarioFormat;
+  }
+}

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotHeader.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotHeader.java
@@ -1,0 +1,49 @@
+package au.com.origin.snapshots;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor
+public class SnapshotHeader extends HashMap<String, String> {
+
+    //
+    // Manual JSON serialization/deserialization as I don't want to
+    // include another dependency for it
+    //
+    @SneakyThrows
+    public String toJson() {
+        StringBuilder b = new StringBuilder();
+        b.append("{\n");
+        final int lastIndex = this.size();
+        int currIndex = 0;
+        for (Map.Entry entry : this.entrySet()) {
+            currIndex++;
+            String format = currIndex == lastIndex ? "  \"%s\": \"%s\"\n" : "  \"%s\": \"%s\",\n";
+            b.append(String.format(format, entry.getKey(), entry.getValue()));
+        }
+        b.append("}");
+        return b.toString();
+    }
+
+    @SneakyThrows
+    public static SnapshotHeader fromJson(String json) {
+        SnapshotHeader snapshotHeader = new SnapshotHeader();
+
+        if (json == null) {
+            return snapshotHeader;
+        }
+
+        String regex = "\\\"(?<key>.*)\\\": \\\"(?<value>.*)\\\"";
+        Pattern p = Pattern.compile(regex);
+        Matcher m = p.matcher(json);
+        while (m.find()) {
+            snapshotHeader.put(m.group("key"), m.group("value"));
+        }
+        return snapshotHeader;
+    }
+}

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotSerializerContext.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotSerializerContext.java
@@ -1,0 +1,57 @@
+package au.com.origin.snapshots;
+
+import au.com.origin.snapshots.annotations.SnapshotName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.lang.reflect.Method;
+
+/**
+ * Contains details of the pending snapshot that can be modified in the Serializer
+ * prior to calling toSnapshot().
+ */
+@AllArgsConstructor
+public class SnapshotSerializerContext {
+
+    @Getter
+    @Setter
+    private String name;
+
+    @Getter
+    @Setter
+    private String scenario;
+
+    @Getter
+    @Setter
+    private SnapshotHeader header;
+
+    @Getter
+    private Class<?> testClass;
+
+    @Getter
+    private final Method testMethod;
+
+    public static SnapshotSerializerContext from(SnapshotContext context) {
+        SnapshotName snapshotName = context.getTestMethod().getAnnotation(SnapshotName.class);
+        String name = snapshotName == null ?
+                context.getTestClass().getName() + "." + context.getTestMethod().getName() :
+                snapshotName.value();
+        return new SnapshotSerializerContext(
+                name,
+                context.getScenario(),
+                context.getHeader(),
+                context.getTestClass(),
+                context.getTestMethod()
+        );
+    }
+
+    public Snapshot toSnapshot(String body) {
+        return Snapshot.builder()
+                .name(name)
+                .scenario(scenario)
+                .header(header)
+                .body(body)
+                .build();
+    }
+}

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotVerifier.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotVerifier.java
@@ -2,6 +2,7 @@ package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.annotations.SnapshotName;
 import au.com.origin.snapshots.annotations.UseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotExtensionException;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,8 @@ public class SnapshotVerifier {
   private final SnapshotConfig config;
   private final boolean failOnOrphans;
 
-  private final Collection<Snapshot> calledSnapshots = Collections.synchronizedCollection(new ArrayList<>());
+  private final Collection<SnapshotContext> calledSnapshots =
+          Collections.synchronizedCollection(new ArrayList<>());
 
   public SnapshotVerifier(SnapshotConfig frameworkSnapshotConfig, Class<?> testClass) {
     this(frameworkSnapshotConfig, testClass, false);
@@ -91,33 +93,35 @@ public class SnapshotVerifier {
   }
 
   @SneakyThrows
-  public Snapshot expectCondition(Method testMethod, Object firstObject, Object... others) {
+  public SnapshotContext expectCondition(Method testMethod, Object firstObject, Object... others) {
     Object[] objects = mergeObjects(firstObject, others);
-    Snapshot snapshot =
-        new Snapshot(config, snapshotFile, testClass, testMethod, objects);
-    calledSnapshots.add(snapshot);
-    return snapshot;
+    SnapshotContext snapshotContext =
+        new SnapshotContext(config, snapshotFile, testClass, testMethod, objects);
+    calledSnapshots.add(snapshotContext);
+    return snapshotContext;
   }
 
   public void validateSnapshots() {
-    Set<String> rawSnapshots = snapshotFile.getRawSnapshots();
+    Set<Snapshot> rawSnapshots = snapshotFile.getSnapshots();
     Set<String> snapshotNames =
-        calledSnapshots.stream().map(Snapshot::getSnapshotName).collect(Collectors.toSet());
-    List<String> unusedRawSnapshots = new ArrayList<>();
+        calledSnapshots.stream().map(SnapshotContext::resolveSnapshotIdentifier).collect(Collectors.toSet());
+    List<Snapshot> unusedSnapshots = new ArrayList<>();
 
-    for (String rawSnapshot : rawSnapshots) {
+    for (Snapshot rawSnapshot : rawSnapshots) {
       boolean foundSnapshot = false;
       for (String snapshotName : snapshotNames) {
-        if (rawSnapshot.contains(snapshotName)) {
+        if (rawSnapshot.getIdentifier().equals(snapshotName)) {
           foundSnapshot = true;
           break;
         }
       }
       if (!foundSnapshot) {
-        unusedRawSnapshots.add(rawSnapshot);
+        unusedSnapshots.add(rawSnapshot);
       }
     }
-    if (unusedRawSnapshots.size() > 0) {
+    if (unusedSnapshots.size() > 0) {
+      List<String> unusedRawSnapshots =
+              unusedSnapshots.stream().map(Snapshot::raw).collect(Collectors.toList());
       String errorMessage = "All unused Snapshots:\n"
           + String.join("\n", unusedRawSnapshots)
           + "\n\nHave you deleted tests? Have you renamed a test method?";

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/annotations/UseSnapshotConfig.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/annotations/UseSnapshotConfig.java
@@ -1,6 +1,6 @@
 package au.com.origin.snapshots.annotations;
 
-import au.com.origin.snapshots.SnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 
 import java.lang.annotation.*;
 

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/comparators/PlainTextEqualsComparator.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/comparators/PlainTextEqualsComparator.java
@@ -1,9 +1,11 @@
 package au.com.origin.snapshots.comparators;
 
+import au.com.origin.snapshots.Snapshot;
+
 public class PlainTextEqualsComparator implements SnapshotComparator {
 
   @Override
-  public boolean matches(String snapshotName, String rawSnapshot, String currentObject) {
-    return rawSnapshot.trim().equals(currentObject.trim());
+  public boolean matches(Snapshot previous, Snapshot current) {
+    return previous.getBody().equals(current.getBody());
   }
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/comparators/SnapshotComparator.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/comparators/SnapshotComparator.java
@@ -1,5 +1,7 @@
 package au.com.origin.snapshots.comparators;
 
+import au.com.origin.snapshots.Snapshot;
+
 public interface SnapshotComparator {
-  boolean matches(String snapshotName, String rawSnapshot, String currentObject);
+  boolean matches(Snapshot previous, Snapshot current);
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/config/PropertyResolvingSnapshotConfig.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/config/PropertyResolvingSnapshotConfig.java
@@ -1,5 +1,6 @@
-package au.com.origin.snapshots;
+package au.com.origin.snapshots.config;
 
+import au.com.origin.snapshots.SnapshotProperties;
 import au.com.origin.snapshots.comparators.SnapshotComparator;
 import au.com.origin.snapshots.reporters.SnapshotReporter;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/config/SnapshotConfig.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/config/SnapshotConfig.java
@@ -1,4 +1,4 @@
-package au.com.origin.snapshots;
+package au.com.origin.snapshots.config;
 
 import au.com.origin.snapshots.comparators.SnapshotComparator;
 import au.com.origin.snapshots.reporters.SnapshotReporter;
@@ -99,4 +99,5 @@ public interface SnapshotConfig {
    * @return boolean indicating if we're running on a CI environment or not
    */
   boolean isCI();
+
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/config/SnapshotConfigInjector.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/config/SnapshotConfigInjector.java
@@ -1,4 +1,4 @@
-package au.com.origin.snapshots;
+package au.com.origin.snapshots.config;
 
 public interface SnapshotConfigInjector {
   SnapshotConfig getSnapshotConfig();

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/exceptions/LogGithubIssueException.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/exceptions/LogGithubIssueException.java
@@ -1,0 +1,12 @@
+package au.com.origin.snapshots.exceptions;
+
+public class LogGithubIssueException extends RuntimeException {
+
+  private static final String LOG_SUPPORT_TICKET =
+          "\n\n*** This exception should never be thrown ***\n" +
+          "Log a support ticket at https://github.com/origin-energy/java-snapshot-testing/issues with details of the exception\n";
+
+  public LogGithubIssueException(String message) {
+    super(message + LOG_SUPPORT_TICKET);
+  }
+}

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/reporters/PlainTextSnapshotReporter.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/reporters/PlainTextSnapshotReporter.java
@@ -1,5 +1,6 @@
 package au.com.origin.snapshots.reporters;
 
+import au.com.origin.snapshots.Snapshot;
 import org.assertj.core.util.diff.DiffUtils;
 import org.assertj.core.util.diff.Patch;
 import org.opentest4j.AssertionFailedError;
@@ -27,13 +28,13 @@ public class PlainTextSnapshotReporter implements SnapshotReporter {
   }
 
   @Override
-  public void report(String snapshotName, String rawSnapshot, String currentObject) {
+  public void report(Snapshot previous, Snapshot current) {
     Patch<String> patch = DiffUtils.diff(
-        Arrays.asList(rawSnapshot.trim().split("\n")),
-        Arrays.asList(currentObject.trim().split("\n")));
+        Arrays.asList(previous.raw().split("\n")),
+        Arrays.asList(current.raw().split("\n")));
 
-    String message = "Error on: \n" + currentObject.trim() + "\n\n" + getDiffString(patch);
+    String message = "Error on: \n" + current.raw() + "\n\n" + getDiffString(patch);
 
-    throw new AssertionFailedError(message, rawSnapshot, currentObject);
+    throw new AssertionFailedError(message, previous.raw(), current.raw());
   }
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/reporters/SnapshotReporter.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/reporters/SnapshotReporter.java
@@ -1,8 +1,10 @@
 package au.com.origin.snapshots.reporters;
 
+import au.com.origin.snapshots.Snapshot;
+
 public interface SnapshotReporter {
 
   boolean supportsFormat(String outputFormat);
 
-  void report(String snapshotName, String rawSnapshot, String currentObject);
+  void report(Snapshot previous, Snapshot current);
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/serializers/Base64SnapshotSerializer.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/serializers/Base64SnapshotSerializer.java
@@ -1,5 +1,8 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
+
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
@@ -16,7 +19,7 @@ public class Base64SnapshotSerializer implements SnapshotSerializer {
       new ToStringSnapshotSerializer();
 
   @Override
-  public String apply(Object[] objects) {
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
     List<?> encoded = Arrays.stream(objects)
         .filter(Objects::nonNull)
         .map(it -> {
@@ -24,7 +27,7 @@ public class Base64SnapshotSerializer implements SnapshotSerializer {
           return Base64.getEncoder().encodeToString(bytes);
         })
         .collect(Collectors.toList());
-    return toStringSnapshotSerializer.apply(encoded.toArray());
+    return toStringSnapshotSerializer.apply(encoded.toArray(), gen);
   }
 
   @Override

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/serializers/SnapshotSerializer.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/serializers/SnapshotSerializer.java
@@ -1,8 +1,10 @@
 package au.com.origin.snapshots.serializers;
 
-import java.util.function.Function;
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
 
-public interface SnapshotSerializer extends Function<Object[], String> {
+import java.util.function.BiFunction;
 
+public interface SnapshotSerializer extends BiFunction<Object[], SnapshotSerializerContext, Snapshot> {
   String getOutputFormat();
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/serializers/ToStringSnapshotSerializer.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/serializers/ToStringSnapshotSerializer.java
@@ -1,6 +1,8 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
 import au.com.origin.snapshots.SnapshotFile;
+import au.com.origin.snapshots.SnapshotSerializerContext;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Arrays;
@@ -15,8 +17,8 @@ import java.util.stream.Collectors;
 public class ToStringSnapshotSerializer implements SnapshotSerializer {
 
   @Override
-  public String apply(Object[] objects) {
-    return "[\n" + Arrays.stream(objects)
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
+    String body = "[\n" + Arrays.stream(objects)
         .map(Object::toString)
         .map(it -> {
           if (it.contains(SnapshotFile.SPLIT_STRING)) {
@@ -27,6 +29,7 @@ public class ToStringSnapshotSerializer implements SnapshotSerializer {
         })
         .collect(Collectors.joining("\n")) +
         "\n]";
+      return gen.toSnapshot(body);
   }
 
   @Override

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/DebugSnapshotTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/DebugSnapshotTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
 import au.com.origin.snapshots.serializers.ToStringSnapshotSerializer;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/OnLoadSnapshotFileTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/OnLoadSnapshotFileTest.java
@@ -1,21 +1,22 @@
 package au.com.origin.snapshots;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.serializers.ToStringSnapshotSerializer;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OnLoadSnapshotFileTest {
 

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/OnSaveSnapshotFileTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/OnSaveSnapshotFileTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.serializers.ToStringSnapshotSerializer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -15,9 +16,9 @@ import java.nio.file.Paths;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-public class onSaveSnapshotFileTest {
+public class OnSaveSnapshotFileTest {
 
-  private static final String SNAPSHOT_FILE_PATH = "src/test/java/au/com/origin/snapshots/__snapshots__/onSaveSnapshotFileTest.snap";
+  private static final String SNAPSHOT_FILE_PATH = "src/test/java/au/com/origin/snapshots/__snapshots__/OnSaveSnapshotFileTest.snap";
   private final SnapshotConfig CUSTOM_SNAPSHOT_CONFIG = new BaseSnapshotConfig() {
     @Override
     public String onSaveSnapshotFile(Class<?> testClass, String snapshotContent) {
@@ -44,7 +45,7 @@ public class onSaveSnapshotFileTest {
     assertThat(String.join("\n", Files.readAllLines(f.toPath())))
         .isEqualTo(
             "HEADER\n"
-                + "au.com.origin.snapshots.onSaveSnapshotFileTest.shouldAllowFileModificationsBeforeFinishingTest=[\n"
+                + "au.com.origin.snapshots.OnSaveSnapshotFileTest.shouldAllowFileModificationsBeforeFinishingTest=[\n"
                 + "Hello Wörld\n"
                 + "]\n"
                 + "FOOTER");

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/OrphanSnapshotTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/OrphanSnapshotTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/ScenarioTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/ScenarioTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
@@ -1,0 +1,60 @@
+package au.com.origin.snapshots;
+
+import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
+import au.com.origin.snapshots.serializers.LowercaseToStringSerializer;
+import au.com.origin.snapshots.serializers.SerializerType;
+import lombok.NoArgsConstructor;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class SnapshotHeaders {
+
+    private static final SnapshotConfig DEFAULT_CONFIG = new BaseSnapshotConfig();
+
+    static SnapshotVerifier snapshotVerifier;
+
+    @BeforeAll
+    static void beforeAll() {
+        SnapshotUtils.copyTestSnapshots();
+        snapshotVerifier = new SnapshotVerifier(DEFAULT_CONFIG, SnapshotHeaders.class);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        snapshotVerifier.validateSnapshots();
+    }
+
+    @Test
+    void shouldBeAbleToSnapshotASingleCustomHeader(TestInfo testInfo) {
+        Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
+        expect.serializer(CustomHeadersSerializer.class).toMatchSnapshot("Hello World");
+    }
+
+    @Test
+    void shouldBeAbleToSnapshotMultipleCustomHeader(TestInfo testInfo) {
+        Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
+        expect.serializer(CustomHeadersSerializer.class).toMatchSnapshot("Hello World");
+    }
+
+    @NoArgsConstructor
+    private static class CustomHeadersSerializer extends LowercaseToStringSerializer {
+        @Override
+        public String getOutputFormat() {
+            return SerializerType.JSON.name();
+        }
+
+        @Override
+        public Snapshot apply(Object[] objects, SnapshotSerializerContext snapshotSerializerContext) {
+            snapshotSerializerContext.getHeader().put("custom", "anything");
+            snapshotSerializerContext.getHeader().put("custom2", "anything2");
+            return super.apply(objects, snapshotSerializerContext);
+        }
+    };
+
+}

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotIntegrationTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotIntegrationTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import au.com.origin.snapshots.serializers.UppercaseToStringSerializer;
 import org.junit.jupiter.api.AfterAll;
@@ -81,6 +82,7 @@ public class SnapshotIntegrationTest {
     Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
     expect.serializer("lowercase").toMatchSnapshot("Hello World");
   }
+
 
   private void matchInsidePrivate(TestInfo testInfo) {
     Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotNameAnnotationWithDuplicatesTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotNameAnnotationWithDuplicatesTest.java
@@ -3,8 +3,6 @@ package au.com.origin.snapshots;
 import au.com.origin.snapshots.annotations.SnapshotName;
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotExtensionException;
-import au.com.origin.snapshots.exceptions.SnapshotMatchException;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/UpdateSnapshotPropertyTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/UpdateSnapshotPropertyTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/UseCustomConfigTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/UseCustomConfigTest.java
@@ -2,6 +2,7 @@ package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.annotations.UseSnapshotConfig;
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.config.ToStringSnapshotConfig;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/UseCustomSerializerTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/UseCustomSerializerTest.java
@@ -1,6 +1,7 @@
 package au.com.origin.snapshots;
 
 import au.com.origin.snapshots.config.BaseSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.serializers.UppercaseToStringSerializer;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/comparators/PlainTextEqualsComparatorTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/comparators/PlainTextEqualsComparatorTest.java
@@ -1,5 +1,6 @@
 package au.com.origin.snapshots.comparators;
 
+import au.com.origin.snapshots.Snapshot;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -9,11 +10,31 @@ class PlainTextEqualsComparatorTest {
 
   @Test
   void successfulComparison() {
-    Assertions.assertThat(COMPARATOR.matches("snap1", "blah", "blah")).isTrue();
+    Snapshot snap1 = Snapshot.builder()
+            .name("snap1")
+            .scenario("A")
+            .body("foo")
+            .build();
+    Snapshot snap2 = Snapshot.builder()
+            .name("snap1")
+            .scenario("A")
+            .body("foo")
+            .build();
+    Assertions.assertThat(COMPARATOR.matches(snap1, snap2)).isTrue();
   }
 
   @Test
   void failingComparison() {
-    Assertions.assertThat(COMPARATOR.matches("snap1", "blah", "blahblah")).isFalse();
+    Snapshot snap1 = Snapshot.builder()
+            .name("snap1")
+            .scenario("A")
+            .body("foo")
+            .build();
+    Snapshot snap2 = Snapshot.builder()
+            .name("snap1")
+            .scenario("A")
+            .body("bar")
+            .build();
+    Assertions.assertThat(COMPARATOR.matches(snap1, snap2)).isFalse();
   }
 }

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/config/BaseSnapshotConfig.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/config/BaseSnapshotConfig.java
@@ -1,6 +1,5 @@
 package au.com.origin.snapshots.config;
 
-import au.com.origin.snapshots.SnapshotConfig;
 import au.com.origin.snapshots.comparators.PlainTextEqualsComparator;
 import au.com.origin.snapshots.comparators.SnapshotComparator;
 import au.com.origin.snapshots.reporters.PlainTextSnapshotReporter;
@@ -42,4 +41,5 @@ public class BaseSnapshotConfig implements SnapshotConfig {
   public boolean isCI() {
     return false;
   }
+
 }

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/config/ToStringSnapshotConfig.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/config/ToStringSnapshotConfig.java
@@ -1,5 +1,7 @@
 package au.com.origin.snapshots.config;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
 import au.com.origin.snapshots.serializers.SerializerType;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
 
@@ -17,8 +19,9 @@ public class ToStringSnapshotConfig extends BaseSnapshotConfig {
       }
 
       @Override
-      public String apply(Object[] objects) {
-        return Arrays.stream(objects).map(Object::toString).collect(Collectors.joining());
+      public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
+        String body = Arrays.stream(objects).map(Object::toString).collect(Collectors.joining());
+        return gen.toSnapshot(body);
       }
     };
   }

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/existing-snapshots/__snapshots__/SnapshotHeaders.snap
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/existing-snapshots/__snapshots__/SnapshotHeaders.snap
@@ -1,0 +1,10 @@
+au.com.origin.snapshots.SnapshotHeaders.shouldBeAbleToSnapshotASingleCustomHeader={
+  "custom": "anything",
+  "custom2": "anything2"
+}hello world
+
+
+au.com.origin.snapshots.SnapshotHeaders.shouldBeAbleToSnapshotMultipleCustomHeader={
+  "custom": "anything",
+  "custom2": "anything2"
+}hello world

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/reporters/PlainTextSnapshotReporterTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/reporters/PlainTextSnapshotReporterTest.java
@@ -1,5 +1,6 @@
 package au.com.origin.snapshots.reporters;
 
+import au.com.origin.snapshots.Snapshot;
 import au.com.origin.snapshots.serializers.SerializerType;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -21,11 +22,21 @@ class PlainTextSnapshotReporterTest {
 
   @Test
   void doReport() {
+    Snapshot snap1 = Snapshot.builder()
+            .name("snap1")
+            .scenario("A")
+            .body("[\nfoo\n]")
+            .build();
+    Snapshot snap2 = Snapshot.builder()
+            .name("snap1")
+            .scenario("A")
+            .body("[\nbar\n]")
+            .build();
     assertThatExceptionOfType(AssertionFailedError.class)
-        .isThrownBy(() -> REPORTER.report("snap1", "blah", "bloo"))
+        .isThrownBy(() -> REPORTER.report(snap1, snap2))
         .withMessageContaining("expecting:")
-        .withMessageContaining("[\"blah\"]")
+        .withMessageContaining("[\"foo\"]")
         .withMessageContaining("but was:")
-        .withMessageContaining("[\"bloo\"]");
+        .withMessageContaining("[\"bar\"]");
   }
 }

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/Base64SnapshotSerializerTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/Base64SnapshotSerializerTest.java
@@ -1,5 +1,8 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
+import au.com.origin.snapshots.SnapshotHeader;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -9,18 +12,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class Base64SnapshotSerializerTest {
 
+  private SnapshotSerializerContext mockSnapshotGenerator = new SnapshotSerializerContext(
+          "base64Test",
+          null,
+          new SnapshotHeader(),
+          Base64SnapshotSerializerTest.class,
+          null // it's not used in these scenarios
+  );
+
   @Test
   void shouldSnapshotAByteArray() {
     Base64SnapshotSerializer serializer = new Base64SnapshotSerializer();
-    String result = serializer.apply(new Object[] {"John Doe".getBytes()});
-    assertThat(result).isEqualTo("[\nSm9obiBEb2U=\n]");
+    Snapshot result = serializer.apply(new Object[] {"John Doe".getBytes()}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\nSm9obiBEb2U=\n]");
   }
 
   @Test
   void shouldSnapshotAnyString() {
     Base64SnapshotSerializer serializer = new Base64SnapshotSerializer();
-    String result = serializer.apply(new Object[] {"John Doe"});
-    assertThat(result).isEqualTo("[\nSm9obiBEb2U=\n]");
+    Snapshot result = serializer.apply(new Object[] {"John Doe"}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\nSm9obiBEb2U=\n]");
   }
 
   @Test
@@ -29,8 +40,8 @@ public class Base64SnapshotSerializerTest {
     File f = new File("src/test/resources/origin-logo.png");
     byte[] content = Files.readAllBytes(f.toPath());
 
-    String result = serializer.apply(new Object[] {content});
-    assertThat(result).isEqualTo(
+    Snapshot result = serializer.apply(new Object[] {content}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo(
         "[\niVBORw0KGgoAAAANSUhEUgAAAFgAAABYCAIAAAD+96djAAAKaklEQVR4nOxce3BcVRk/59zX3t3N5p3m1UeaNLQ2adKaFhDp9MFD3j7Qoqhg1VHpjEMR7CgKyghVQKa24wzSUhQcxwGLU0TsH0AphQLSxKSQJm02aRrSvDbPfd/HOddZ2LLJZp/n3F0aJr/Zf7J77nd+95fvfN85537n8oZhgHkAgD5pAhcK5oUIY16IMOaFCGNeiDD4rPVEpiZ1p1PvceLhITIyQlwuw+c1FMVQFGAYUJKAJEFZ5oqKUUkJKlnAL63mq5dxxcXZoQczmj7xqEtrflc7fUprbSGuEQoLMC9fbFzN1y4X1zRx5RUZ4Hi+o0wIQdxu5Y0jyuuv6p0dwDz73JIqacMmaf0mrrDILJsfw2Qh9L7ewMF/KEdfA5pmotkZQEhcd6l801eE5StNtGqaEHrfWf8z+9T/vWuiCyQGv2Kl7datwoo6U6yZI4Ty9lH/M0/i4UEzKKUB5Mi1bvm2ZfMXAM8a9VmFwMODvn171LZmRh4s4BYusf/gTqF2BYsRBiEwDhw66H/2L6H890kDIiRddb3tlq3QYqG0QCcEcU96//iw9l4LXa8ZAle5KOeu+7lSmixLI4Tu7PTseZCMuij6yzSg1WbftkNsXJf2hekKob7X7Nn1AFA/+eEQF4iz3bbNsunatC5KTwjl7SPevY8CPWNzBPMg33y79YZbUm+fRtZR3n7N+6ffhaYJkIpadhE48GcIoXz9lhTbpyqE2vqW78lHAJwbKnwE//NPAQ7J13w1lcYpCaF1d3gf3wkMAtHckeFDBA7sR3kF0qWbk7ZMLgSZHPM98RAg2hzdu/D9dTcqKhGW1SduliRY4vER3/5H9K73zaaXXUhS3kNPI7sjQZOEQhDi3nOv3tmaEXLZBbdoWe5dDwMp7rwzkbsHj76on24NNZn7H9zf5Xt+b4KbjSsEHh8JHHwqlCM+LR/l2EvaqbjeHTdYBl96xtAVYHaagILIV63ga1bxC2tQSQVy5ENeABACTSN+Dx45hwfO6N3va10njIDP3K5DSeTgPuHuPwDExSAWM0boHzg9j90JDGIiCW5hjXTZdWLDZVC2J2+tKWr7u8obL+rOEyZyAABYv7FdWnfl7O9jC+F54j6987hZfaOSSutN3xdWrKW4VjvTHvjXftzbCYA5G1+oYEHuz/YCLnooxBBC73d6dv3YlH6hbJO/vE1adRngBXorhGi9J/1/f4yMDZnACQDrLdultdFOESNYKq89F4ouzIGaW1ids323tGYDkwof7tYKS+sc23cLK9eZkkGCh58DBCcRgkyNqu3H2DsTVl7suONRrrCMSYJpgLLdfvsvpctvZOdGxvq17ujQEy2E2vwyMDBjouJr19i/dS8QJbNUOE+Ws974Q8umLeypVG15Jcp2dMzQuo4zrqygLdf6xTtmRyOzIG/cop8+jgd7WIzoPW0AY8BF8ugMj8DjQ7ivg0lsBK03b+cKy1lYJoFosd76c2i1sfA0vOPa2RkLqBlC6M5mxuEnXnKdcBFNmkwLXEGZfMOPGKnqXc1xhdC6W1hMw/xi65W3ZVqFjyA2bOSrG1jYat3xhCAE97ax+Ju86ZtAsmZHiFCwuHpraAVAy5a4eolvMoYQeKzf0ALUAqPCMrF+Q9ZUCA2QshrhIoaZBQR4sCuWEENOpujQeEXmMkU8iE3XsnDGg86PTUWo4+EelsQp1K1nvq/0O61qRPY8wz9FdzkeieTgiEcQ9zD1eENFFVx+JlNmPHA8t6SePky4R2IIYXhc1D7GLTKnSIEC/KJ6atqGJyJEZGgQ7yig3afmihebcE/UXdPSNhQP0BQgSDOEMDQfoA0RqCCDZV5Jus4vp6Yd+vcrPjRDCIIB0amlhdZEO+UZBbLmfrifSLt9ooefZp8XQldhSAVKbaGYvXlUNBAHJSnk4VQwooWAiNodQiA6w8XMgICe/PmN3PNCCFLIwWjLiAzVT0vEDBCVOkxAPrxpMm0uKEpAC9KZM7wuAJhquagRSnYsz+iFWUJAW67hphSCTJ2jJcIKMtHPMi6QFH62EBEC5ZRg7zCdQezqouXCCjzcQS0EyimaFSMAQI5iTLtdjodPAqxnf9EVSneDJ+gDRE6k9H+aEHmV9Isu3a8NtAoLmygvpwXxjxNXBzVtlBdZH0W8iiuuYVnS6l3R+8JZgOY8DAChXyIVVn1sappH5FayzFX1wVag+oBoY725dID73mLhjByRxy4Rj0D2YmgroHcK3ad0/pv1ztKBPtiGx04zeDFEhdUxhAiNjvJGltGhnXyeBCayJAPWlOP7WNiioqVIzostBF/ewPSwQPerLfuzo4PSfoBMnWVhy1fOCO0zEh5XtjqUAo3oB6SpQzv7OregTqi5muEekwO7Tqonn2UsYuErL57x5/Q/kJzHVzbhc++wdKC07IX2BXxpI4uRBCA+V/DYoxBgllUidCzkCmumfxNtTKi+isXfQh9DCx7bicczMtc0/KOBI/cZwTFGkkLVxijL0ULwpathTglLEAp9cDBw5Bf6cJu5KhDPgP/wDsM3wEqPF/glyYQAiBOqr2HtCQFAgsE3f612PDu7JIMOev+b/sN3G8FRdm784vVILoiyH6uGSvV6D30XYMqVaBS4guVC7Zf4skuoLeAJp+Z8Qe8/YgofAKC8eTfnWBT9bcxiMqX9aa3rgEkdh8CVNIq1X+OK0jupid29Wtc/9f6jLIksCnzF5y1r75n9fZwSZC3gP7zNCI6b1X24M8divmI9v6AJORJt/xPvOTzSrA8cI+OnzCqmCwPx8sY9yBajoCluLbb2watq224zSUyHlMc5qqC9AooOiMTQZAxrhuo2vOeI+4yhZGp6yi+9UfrM1pg/JSpKD/73V3j001CR/hGgvMB6+S7AyzF/TTQpEevuAILMOq24QD4ISvXb4qmQ/LyG1v+y2vEEIGo60l+IEJd/T1h8fYIGSTbXhMorIOKV9l0m84I8tBRBIQciCXASgBBgxcAK0H0kOAqIyWcpuaK1iVVI6SgTX74Buzv1/kMsVKBcyuXWopwa5KhG1jIo5SUYlYY6RQJDxNND3N3E7SS+syxvIODyV1oafpqcYUrnPokWbPsNmUizUF7M5Ys/h/JXoZylSC5J79ppMFQ38fTgiTY88qYRTO/4MbRWyGseBGJu8papHoDVA4HWew3vmRQ657jCJr50M1ewGiBz97UJnmjXB1/Bo2+lEragVCyt2YmkwlRMp3MSWJ0MnLjf8PXFbcDLfOkVfPm1SC5N1SYVDHVSGzikD/4HqO54baBUIK16AFlTrVdI70i0obmDrTuMYIznHyi3Tlr+EyjmpW6NFbpfcT6OXUdj/MRZLA2/RbY0ylfSf1sADgbadhj+iF9AqUhafg/KqU3PjkkggSH11O+J1zmNT6Glfie0pPfeJqr3R2hu5fRjeKotNBqKN4pV3wF8TtpGTATRtL6/aYMvAIMg+zLponuglPbbq6jfKEK0/gPItpTL/yzV5eYDe06RiXeEyq8DRHNOJrMv5JpDmJvnvTOAeSHCmBcijHkhwpgXIox5IcKYFyKM/wcAAP//h4bYYlJz5AYAAAAASUVORK5CYII=\n]");
   }
 

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/LowercaseToStringSerializer.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/LowercaseToStringSerializer.java
@@ -1,12 +1,16 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
+
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class LowercaseToStringSerializer implements SnapshotSerializer {
   @Override
-  public String apply(Object[] objects) {
-    return Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toLowerCase();
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
+    String body = Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toLowerCase();
+    return gen.toSnapshot(body);
   }
 
   @Override

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/ToStringSnapshotSerializerTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/ToStringSnapshotSerializerTest.java
@@ -1,5 +1,8 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
+import au.com.origin.snapshots.SnapshotHeader;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.junit.jupiter.api.Test;
@@ -9,28 +12,36 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ToStringSnapshotSerializerTest {
   ToStringSnapshotSerializer serializer = new ToStringSnapshotSerializer();
 
+  private SnapshotSerializerContext mockSnapshotGenerator = new SnapshotSerializerContext(
+          "base64Test",
+          null,
+          new SnapshotHeader(),
+          ToStringSnapshotSerializerTest.class,
+          null // it's not used in these scenarios
+  );
+
   @Test
   void shouldSnapshotAnyString() {
-    String result = serializer.apply(new Object[] {"John Doe"});
-    assertThat(result).isEqualTo("[\nJohn Doe\n]");
+    Snapshot result = serializer.apply(new Object[] {"John Doe"}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\nJohn Doe\n]");
   }
 
   @Test
   void shouldSnapshotUnicode() {
-    String result = serializer.apply(new Object[] {"🤔"});
-    assertThat(result).isEqualTo("[\n🤔\n]");
+    Snapshot result = serializer.apply(new Object[] {"🤔"}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\n🤔\n]");
   }
 
   @Test
   void shouldSnapshotAnyObject() {
-    String result = serializer.apply(new Object[] {new Dummy(1, "John Doe")});
-    assertThat(result).isEqualTo("[\nToStringSerializerTest.Dummy(id=1, name=John Doe)\n]");
+    Snapshot result = serializer.apply(new Object[] {new Dummy(1, "John Doe")}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\nToStringSerializerTest.Dummy(id=1, name=John Doe)\n]");
   }
 
   @Test
   void shouldSnapshotMultipleObjects() {
-    String result = serializer.apply(new Object[] {new Dummy(1, "John Doe"), new Dummy(2, "Sarah Doe")});
-    assertThat(result).isEqualTo("[\nToStringSerializerTest.Dummy(id=1, name=John Doe)\nToStringSerializerTest.Dummy(id=2, name=Sarah Doe)\n]");
+    Snapshot result = serializer.apply(new Object[] {new Dummy(1, "John Doe"), new Dummy(2, "Sarah Doe")}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\nToStringSerializerTest.Dummy(id=1, name=John Doe)\nToStringSerializerTest.Dummy(id=2, name=Sarah Doe)\n]");
   }
 
   @Test
@@ -40,8 +51,8 @@ public class ToStringSnapshotSerializerTest {
 
   @Test
   void shouldReplaceThreeConsecutiveNewLines() {
-    String result = serializer.apply(new Object[] {"John\n\n\nDoe"});
-    assertThat(result).isEqualTo("[\nJohn\n.\n.\nDoe\n]");
+    Snapshot result = serializer.apply(new Object[] {"John\n\n\nDoe"}, mockSnapshotGenerator);
+    assertThat(result.getBody()).isEqualTo("[\nJohn\n.\n.\nDoe\n]");
   }
 
   @AllArgsConstructor

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/UppercaseToStringSerializer.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/serializers/UppercaseToStringSerializer.java
@@ -1,12 +1,16 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
+
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class UppercaseToStringSerializer implements SnapshotSerializer {
   @Override
-  public String apply(Object[] objects) {
-    return Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toUpperCase();
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
+    String body = Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toUpperCase();
+    return gen.toSnapshot(body);
   }
 
   @Override

--- a/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
+++ b/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
@@ -1,6 +1,9 @@
 package au.com.origin.snapshots.junit4;
 
 import au.com.origin.snapshots.*;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfigInjector;
 import org.junit.runner.Description;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotContextRuleUsedTest.snap
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotContextRuleUsedTest.snap
@@ -1,0 +1,31 @@
+au.com.origin.snapshots.SnapshotRuleUsedTest.shouldUseExtension=[
+Hello World
+]
+
+
+au.com.origin.snapshots.SnapshotRuleUsedTest.shouldUseExtensionAgain=[
+Hello World
+Hello World Again
+]
+
+
+au.com.origin.snapshots.SnapshotRuleUsedTest.shouldUseExtensionAgainViaInstanceVariable=[
+Hello World
+Hello World Again
+]
+
+
+au.com.origin.snapshots.SnapshotRuleUsedTest.shouldUseExtensionViaInstanceVariable=[
+Hello World
+]
+
+
+hello_world=[
+Hello World
+]
+
+
+hello_world_again=[
+Hello World
+Hello World Again
+]

--- a/java-snapshot-testing-junit5/src/main/java/au/com/origin/snapshots/junit5/SnapshotExtension.java
+++ b/java-snapshot-testing-junit5/src/main/java/au/com/origin/snapshots/junit5/SnapshotExtension.java
@@ -1,6 +1,10 @@
 package au.com.origin.snapshots.junit5;
 
-import au.com.origin.snapshots.*;
+import au.com.origin.snapshots.Expect;
+import au.com.origin.snapshots.SnapshotVerifier;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfigInjector;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.*;
@@ -55,7 +59,7 @@ public class SnapshotExtension implements AfterAllCallback, BeforeAllCallback, S
       }
     } catch (Exception e) {
       log.error(
-          "FAILED: (Java Snapshot Testing) Unable to get JUnit5 ClassTestDescriptor!\n" +
+          "FAILED: (Java Snapshot Testing) Unable to get JUnit5 ClassTestDescriptor or ClassBasedTestDescriptor!\n" +
               "Ensure you are using Junit5 >= 5.3.2\n" +
               "This may be due to JUnit5 changing their private api as we use reflection to access it\n" +
               "Log a support ticket https://github.com/origin-energy/java-snapshot-testing/issues and supply your JUnit5 version\n" +

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotContextExtensionUsedTest.snap
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotContextExtensionUsedTest.snap
@@ -1,0 +1,32 @@
+au.com.origin.snapshots.SnapshotExtensionUsedTest.shouldUseExtension=[
+Hello World
+]
+
+
+au.com.origin.snapshots.SnapshotExtensionUsedTest.shouldUseExtensionAgain=[
+Hello World
+Hello World Again
+]
+
+
+au.com.origin.snapshots.SnapshotExtensionUsedTest.shouldUseExtensionAgainViaInstanceVariable=[
+Hello World
+Hello World Again
+]
+
+
+au.com.origin.snapshots.SnapshotExtensionUsedTest.shouldUseExtensionViaInstanceVariable=[
+Hello World
+]
+
+
+hello_world=[
+Hello World
+Hello World
+]
+
+
+hello_world_2=[
+Hello World
+Hello World Again
+]

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/CustomFrameworkExample.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/CustomFrameworkExample.java
@@ -1,8 +1,8 @@
 package au.com.origin.snapshots.docs;
 
 import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.SnapshotVerifier;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/JUnit5Example.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/JUnit5Example.java
@@ -1,9 +1,9 @@
 package au.com.origin.snapshots.docs;
 
+import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.junit5.SnapshotExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import au.com.origin.snapshots.Expect;
 
 // Ensure you extend your test class with the SnapshotExtension
 @ExtendWith({SnapshotExtension.class})

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/LowercaseToStringSerializer.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/LowercaseToStringSerializer.java
@@ -1,5 +1,7 @@
 package au.com.origin.snapshots.docs;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
 import au.com.origin.snapshots.serializers.SerializerType;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
 
@@ -8,8 +10,9 @@ import java.util.stream.Collectors;
 
 public class LowercaseToStringSerializer implements SnapshotSerializer {
   @Override
-  public String apply(Object[] objects) {
-    return Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toLowerCase();
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
+    String body = Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toLowerCase();
+    return gen.toSnapshot(body);
   }
 
   @Override

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/LowercaseToStringSnapshotConfig.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/LowercaseToStringSnapshotConfig.java
@@ -1,6 +1,6 @@
 package au.com.origin.snapshots.docs;
 
-import au.com.origin.snapshots.PropertyResolvingSnapshotConfig;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
 
 public class LowercaseToStringSnapshotConfig extends PropertyResolvingSnapshotConfig {

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/MyFirstSnapshotTest.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/MyFirstSnapshotTest.java
@@ -1,5 +1,6 @@
 package au.com.origin.snapshots.docs;
 
+import au.com.origin.snapshots.Expect;
 import au.com.origin.snapshots.annotations.SnapshotName;
 import au.com.origin.snapshots.junit5.SnapshotExtension;
 import org.junit.jupiter.api.Test;
@@ -7,7 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.HashMap;
 import java.util.Map;
-import au.com.origin.snapshots.Expect;
 
 @ExtendWith({SnapshotExtension.class})
 public class MyFirstSnapshotTest {

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/UppercaseToStringSerializer.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/UppercaseToStringSerializer.java
@@ -1,5 +1,7 @@
 package au.com.origin.snapshots.docs;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
 import au.com.origin.snapshots.serializers.SerializerType;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
 
@@ -8,8 +10,9 @@ import java.util.stream.Collectors;
 
 public class UppercaseToStringSerializer implements SnapshotSerializer {
   @Override
-  public String apply(Object[] objects) {
-    return Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toUpperCase();
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
+    String body = Arrays.stream(objects).map(Object::toString).collect(Collectors.joining()).toUpperCase();
+    return gen.toSnapshot(body);
   }
 
   @Override

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/__snapshots__/CustomSnapshotContextConfigExample.snap
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/__snapshots__/CustomSnapshotContextConfigExample.snap
@@ -1,0 +1,1 @@
+au.com.origin.snapshots.docs.CustomSnapshotConfigExample.myTest=hello world

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/__snapshots__/MyFirstSnapshotContextTest.snap
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/docs/__snapshots__/MyFirstSnapshotContextTest.snap
@@ -1,0 +1,11 @@
+au.com.origin.snapshots.docs.MyFirstSnapshotTest.jsonSerializationTest=[
+  {
+    "age": 40,
+    "name": "John Doe"
+  }
+]
+
+
+i_can_give_custom_names_to_my_snapshots=[
+Hello World
+]

--- a/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/serializers/JacksonSnapshotSerializer.java
+++ b/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/serializers/JacksonSnapshotSerializer.java
@@ -1,5 +1,7 @@
 package au.com.origin.snapshots.serializers;
 
+import au.com.origin.snapshots.Snapshot;
+import au.com.origin.snapshots.SnapshotSerializerContext;
 import au.com.origin.snapshots.exceptions.SnapshotExtensionException;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -65,9 +67,10 @@ public class JacksonSnapshotSerializer implements SnapshotSerializer {
   }
 
   @Override
-  public String apply(Object[] objects) {
+  public Snapshot apply(Object[] objects, SnapshotSerializerContext gen) {
     try {
-      return objectMapper.writer(pp).writeValueAsString(objects);
+      String body = objectMapper.writer(pp).writeValueAsString(objects);
+      return  gen.toSnapshot(body);
     } catch (Exception e) {
       throw new SnapshotExtensionException("Jackson Serialization failed", e);
     }

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/CustomSerializerTest.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/CustomSerializerTest.java
@@ -1,8 +1,8 @@
 package au.com.origin.snapshots.docs;
 
 import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.SnapshotVerifier;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/HibernateSnapshotSerializer.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/HibernateSnapshotSerializer.java
@@ -1,9 +1,9 @@
 package au.com.origin.snapshots.docs;
 
 import au.com.origin.snapshots.serializers.DeterministicJacksonSnapshotSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.time.Instant;
 import java.util.List;

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/JsonAssertReporter.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/JsonAssertReporter.java
@@ -1,5 +1,6 @@
 package au.com.origin.snapshots.docs;
 
+import au.com.origin.snapshots.Snapshot;
 import au.com.origin.snapshots.reporters.SnapshotReporter;
 import au.com.origin.snapshots.serializers.SerializerType;
 import lombok.SneakyThrows;
@@ -14,7 +15,7 @@ public class JsonAssertReporter implements SnapshotReporter {
 
   @Override
   @SneakyThrows
-  public void report(String snapshotName, String rawSnapshot, String currentObject) {
-    JSONAssert.assertEquals(rawSnapshot, currentObject, JSONCompareMode.STRICT);
+  public void report(Snapshot previous, Snapshot current) {
+    JSONAssert.assertEquals(previous.getBody(), current.getBody(), JSONCompareMode.STRICT);
   }
 }

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/JsonObjectComparator.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/docs/JsonObjectComparator.java
@@ -1,17 +1,18 @@
 package au.com.origin.snapshots.docs;
 
+import au.com.origin.snapshots.Snapshot;
 import au.com.origin.snapshots.comparators.SnapshotComparator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 
 public class JsonObjectComparator implements SnapshotComparator {
   @Override
-  public boolean matches(String snapshotName, String rawSnapshot, String currentObject) {
-    return asObject(snapshotName, rawSnapshot).equals(asObject(snapshotName, currentObject));
+  public boolean matches(Snapshot previous, Snapshot current) {
+    return asObject(previous.getName(), previous.getBody()).equals(asObject(current.getName(), current.getBody()));
   }
 
   @SneakyThrows
   private static Object asObject(String snapshotName, String json) {
-    return new ObjectMapper().readValue(json.replaceFirst(snapshotName, ""), Object.class);
+    return new ObjectMapper().readValue(json.replaceFirst(snapshotName + "=", ""), Object.class);
   }
 }

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/serializers/DeterministicJacksonSnapshotSerializerTest.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/serializers/DeterministicJacksonSnapshotSerializerTest.java
@@ -1,8 +1,8 @@
 package au.com.origin.snapshots.serializers;
 
 import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.SnapshotVerifier;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/serializers/JacksonSnapshotSerializerTest.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/serializers/JacksonSnapshotSerializerTest.java
@@ -1,9 +1,8 @@
 package au.com.origin.snapshots.serializers;
 
-import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.PropertyResolvingSnapshotConfig;
-import au.com.origin.snapshots.SnapshotConfig;
-import au.com.origin.snapshots.SnapshotVerifier;
+import au.com.origin.snapshots.*;
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
+import au.com.origin.snapshots.config.SnapshotConfig;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -23,6 +22,14 @@ public class JacksonSnapshotSerializerTest {
     }
   };
 
+  private SnapshotSerializerContext gen = new SnapshotSerializerContext(
+    "test",
+    null,
+    new SnapshotHeader(),
+    JacksonSnapshotSerializerTest.class,
+    null
+  );
+
   @Test
   public void shouldSerializeMap() {
     Map<String, Object> map = new HashMap<>();
@@ -30,8 +37,8 @@ public class JacksonSnapshotSerializerTest {
     map.put("age", 40);
 
     SnapshotSerializer serializer = new JacksonSnapshotSerializer();
-    String result = serializer.apply(new Object[] {map});
-    Assertions.assertThat(result).isEqualTo("[\n" +
+    Snapshot result = serializer.apply(new Object[] {map}, gen);
+    Assertions.assertThat(result.getBody()).isEqualTo("[\n" +
         "  {\n" +
         "    \"age\": 40,\n" +
         "    \"name\": \"John Doe\"\n" +

--- a/java-snapshot-testing-spock/src/main/groovy/au/com/origin/snapshots/spock/SnapshotExtension.groovy
+++ b/java-snapshot-testing-spock/src/main/groovy/au/com/origin/snapshots/spock/SnapshotExtension.groovy
@@ -1,9 +1,9 @@
 package au.com.origin.snapshots.spock
 
-import au.com.origin.snapshots.PropertyResolvingSnapshotConfig
-import au.com.origin.snapshots.SnapshotConfig
-import au.com.origin.snapshots.SnapshotConfigInjector
 import au.com.origin.snapshots.SnapshotVerifier
+import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig
+import au.com.origin.snapshots.config.SnapshotConfig
+import au.com.origin.snapshots.config.SnapshotConfigInjector
 import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
 import org.spockframework.runtime.model.SpecInfo
 

--- a/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/docs/SpockExample.groovy
+++ b/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/docs/SpockExample.groovy
@@ -1,10 +1,9 @@
 package au.com.origin.snapshots.docs
 
+import au.com.origin.snapshots.Expect
 import au.com.origin.snapshots.annotations.SnapshotName
 import au.com.origin.snapshots.spock.EnableSnapshots
 import spock.lang.Specification
-
-import au.com.origin.snapshots.Expect;
 
 // Ensure you enable snapshot testing support
 @EnableSnapshots


### PR DESCRIPTION
Breaking changes for Serailizers, Comparators & Reporters
- Now accept a Snapshot class as the arguments
- Still have access to everything they had before via the getters
- Exposed lots more information for the serializer to customise the snapshot as desired

SnapshotHeaders
- Users can now use custom headers via expect.header("A", "B").toMatchSnapshot(obj)
- These headers are serialized into the snapshot as a JSON Object

REGEX matching
- The Snapshot object is now parsed as a regular expression and key pieces of information are extracted