### PR TITLE
Fixes #90: Deprecate varargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,20 +173,19 @@ A text representation of your java object (toString() or JSON).
 **String snapshot example**
 
 ```java
-expect("hello world","Hello world again!").toMatchSnapshot();
+expect.toMatchSnapshot("Hello World");
 ```
 
 ```text
 au.com.example.company.HelloWorldTest.helloWorld=[
 Hello world
-Hello world again!
 ]
 ```
 
 **JSON Snapshot Example**
 
 ```java
-expect(userDto).serializer("json").toMatchSnapshot();
+expect.serializer("json").toMatchSnapshot(userDto);
 ```
 
 ```text
@@ -529,8 +528,8 @@ Currently, we support the following serializers.
 
 Serializers are resolved in the following order.
 
-- (method level) explicitly `expect(...).serializer(ToStringSerializer.class).toMatchSnapshot();` or via property
-  file `expect(...).serializer("json").toMatchSnapshot();`
+- (method level) explicitly `expect.serializer(ToStringSerializer.class).toMatchSnapshot(...);` or via property
+  file `expect.serializer("json").toMatchSnapshot(...);`
 - (class level) explicitly `@UseSnapshotConfig` which gets read from the `getSerializer()` method
 - (properties) implicitly via `snapshot.properties`
 

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Expect.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Expect.java
@@ -27,10 +27,27 @@ public class Expect {
   /**
    * Make an assertion on the given input parameters against what already exists
    *
+   * If you were previously using varargs and see an error - you can fix the error using
+   * "toMatchSnapshotLegacy", however, a better approach is to use the ".scenario()"
+   * feature as future versions of this library will most likely remove the legacy implementation completely.
+   *
+   * @param object snapshot object
+   */
+  public void toMatchSnapshot(Object object) {
+    toMatchSnapshotLegacy(object);
+  }
+
+  /**
+   * Make an assertion on the given input parameters against what already exists
+   *
+   * Previously called `toMatchSnapshot`, this varargs implementation will be removed
+   * in future versions of this library.
+   *
    * @param firstObject first snapshot object
    * @param objects     other snapshot objects
    */
-  public void toMatchSnapshot(Object firstObject, Object... objects) {
+  @Deprecated
+  public void toMatchSnapshotLegacy(Object firstObject, Object... objects) {
     Snapshot snapshot = snapshotVerifier.expectCondition(testMethod, firstObject, objects);
     if (snapshotSerializer != null) {
       snapshot.setSnapshotSerializer(snapshotSerializer);

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/BackwardCompatilbleTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/BackwardCompatilbleTest.java
@@ -72,7 +72,7 @@ public class BackwardCompatilbleTest {
             new SnapshotCaptor(Object.class, FakeObject.class));
 
     Expect.of(snapshotVerifier, testInfo.getTestMethod().get())
-        .toMatchSnapshot(fakeMethodWithComplexObjectWithIgnore, fakeMethodWithComplexObjectWithoutIgnore);
+        .toMatchSnapshotLegacy(fakeMethodWithComplexObjectWithIgnore, fakeMethodWithComplexObjectWithoutIgnore);
 
     snapshotVerifier.validateSnapshots();
   }

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotMatcherScenarioTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotMatcherScenarioTest.java
@@ -59,7 +59,7 @@ class SnapshotMatcherScenarioTest {
     Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
     expect
         .scenario("Scenario B")
-        .toMatchSnapshot("any second type of object", "any third type of object");
+        .toMatchSnapshotLegacy("any second type of object", "any third type of object");
     File f = new File(FILE_PATH);
     if (!f.exists() || f.isDirectory()) {
       throw new RuntimeException("File should exist here");

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotMatcherTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotMatcherTest.java
@@ -57,7 +57,7 @@ class SnapshotMatcherTest {
   @Test
   void should2SecondSnapshotExecutionSuccessfully(TestInfo testInfo) {
     Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
-    expect.toMatchSnapshot("any second type of object", "any third type of object");
+    expect.toMatchSnapshotLegacy("any second type of object", "any third type of object");
     File f = new File(FILE_PATH);
     if (!f.exists() || f.isDirectory()) {
       throw new RuntimeException("File should exist here");

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotUtilsTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotUtilsTest.java
@@ -58,7 +58,7 @@ class SnapshotUtilsTest {
 
     SnapshotVerifier snapshotVerifier = new SnapshotVerifier(new BaseSnapshotConfig(), testInfo.getTestClass().get());
     Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
-    expect.toMatchSnapshot(fakeMethodWithComplexObjectWithIgnore, fakeMethodWithComplexObjectWithoutIgnore);
+    expect.toMatchSnapshotLegacy(fakeMethodWithComplexObjectWithIgnore, fakeMethodWithComplexObjectWithoutIgnore);
     snapshotVerifier.validateSnapshots();
   }
 
@@ -88,7 +88,7 @@ class SnapshotUtilsTest {
     SnapshotVerifier snapshotVerifier = new SnapshotVerifier(new BaseSnapshotConfig(), testInfo.getTestClass().get());
     Expect expect = Expect.of(snapshotVerifier, testInfo.getTestMethod().get());
     expect
-        .toMatchSnapshot(fakeMethodWithComplexObjectWithIgnore, fakeMethodWithComplexObjectWithoutIgnore);
+        .toMatchSnapshotLegacy(fakeMethodWithComplexObjectWithIgnore, fakeMethodWithComplexObjectWithoutIgnore);
     snapshotVerifier.validateSnapshots();
   }
 }

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/SnapshotRuleUsedTest.java
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/SnapshotRuleUsedTest.java
@@ -24,7 +24,7 @@ public class SnapshotRuleUsedTest {
 
   @Test
   public void shouldUseExtensionAgainViaInstanceVariable() {
-    this.expect.toMatchSnapshot("Hello World", "Hello World Again");
+    this.expect.toMatchSnapshot("Hello World");
   }
 
   @SnapshotName("hello_world")

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/SnapshotRunnerUsedTest.java
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/SnapshotRunnerUsedTest.java
@@ -17,7 +17,7 @@ public class SnapshotRunnerUsedTest {
 
   @Test
   public void shouldUseExtensionAgain(Expect expect) {
-    expect.toMatchSnapshot("Hello World", "Hello World Again");
+    expect.toMatchSnapshot("Hello World");
   }
 
   @Test
@@ -27,7 +27,7 @@ public class SnapshotRunnerUsedTest {
 
   @Test
   public void shouldUseExtensionAgainViaInstanceVariable() {
-    this.expect.toMatchSnapshot("Hello World", "Hello World Again");
+    this.expect.toMatchSnapshot("Hello World");
   }
 
   @SnapshotName("hello_world")
@@ -39,6 +39,6 @@ public class SnapshotRunnerUsedTest {
   @SnapshotName("hello_world_again")
   @Test
   public void shouldUseExtensionAgainWithSnapshotName(Expect expect) {
-    expect.toMatchSnapshot("Hello World", "Hello World Again");
+    expect.toMatchSnapshot("Hello World");
   }
 }

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotRuleUsedTest.snap
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotRuleUsedTest.snap
@@ -1,6 +1,5 @@
 au.com.origin.snapshots.SnapshotRuleUsedTest.shouldUseExtensionAgainViaInstanceVariable=[
 Hello World
-Hello World Again
 ]
 
 

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotRunnerUsedTest.snap
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotRunnerUsedTest.snap
@@ -5,13 +5,11 @@ Hello World
 
 au.com.origin.snapshots.SnapshotRunnerUsedTest.shouldUseExtensionAgain=[
 Hello World
-Hello World Again
 ]
 
 
 au.com.origin.snapshots.SnapshotRunnerUsedTest.shouldUseExtensionAgainViaInstanceVariable=[
 Hello World
-Hello World Again
 ]
 
 
@@ -27,5 +25,4 @@ Hello World
 
 hello_world_again=[
 Hello World
-Hello World Again
 ]

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/SnapshotExtensionUsedTest.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/SnapshotExtensionUsedTest.java
@@ -17,7 +17,7 @@ public class SnapshotExtensionUsedTest {
 
   @Test
   public void shouldUseExtensionAgain(Expect expect) {
-    expect.toMatchSnapshot("Hello World", "Hello World Again");
+    expect.toMatchSnapshot("Hello World");
   }
 
   @Test
@@ -27,19 +27,19 @@ public class SnapshotExtensionUsedTest {
 
   @Test
   public void shouldUseExtensionAgainViaInstanceVariable() {
-    expect.toMatchSnapshot("Hello World", "Hello World Again");
+    expect.toMatchSnapshot("Hello World");
   }
 
   @SnapshotName("hello_world")
   @Test
   public void snapshotWithName() {
-    expect.toMatchSnapshot("Hello World", "Hello World");
+    expect.toMatchSnapshot("Hello World");
   }
 
   @SnapshotName("hello_world_2")
   @Test
   public void snapshotWithNameAgain() {
-    expect.toMatchSnapshot("Hello World", "Hello World Again");
+    expect.toMatchSnapshot("Hello World");
   }
 
 }

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotExtensionUsedTest.snap
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/SnapshotExtensionUsedTest.snap
@@ -5,13 +5,11 @@ Hello World
 
 au.com.origin.snapshots.SnapshotExtensionUsedTest.shouldUseExtensionAgain=[
 Hello World
-Hello World Again
 ]
 
 
 au.com.origin.snapshots.SnapshotExtensionUsedTest.shouldUseExtensionAgainViaInstanceVariable=[
 Hello World
-Hello World Again
 ]
 
 
@@ -22,11 +20,9 @@ Hello World
 
 hello_world=[
 Hello World
-Hello World
 ]
 
 
 hello_world_2=[
 Hello World
-Hello World Again
 ]

--- a/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/SpockExtensionUsedSpec.groovy
+++ b/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/SpockExtensionUsedSpec.groovy
@@ -22,7 +22,7 @@ class SpockExtensionUsedSpec extends Specification {
     @SnapshotName("Should use extension again")
     def "Should use extension again"(Expect expect) {
         when:
-        expect.toMatchSnapshot("Hello World", "Hello World Again")
+        expect.toMatchSnapshot("Hello World")
 
         then:
         true

--- a/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/__snapshots__/SpockExtensionUsedSpec.snap
+++ b/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/__snapshots__/SpockExtensionUsedSpec.snap
@@ -25,7 +25,6 @@ DataTable example 2[number]=[
 
 Should use extension again=[
 Hello World
-Hello World Again
 ]
 
 


### PR DESCRIPTION
Remove varargs as it can cause snapshot failures when there are trailing and leading whitespace between snapshots.