### PR TITLE
Fixes #103: jackson-datatype-* peer dependencies are now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@ testImplementation 'io.github.origin-energy:java-snapshot-testing-junit5:3.2.+'
 testImplementation 'io.github.origin-energy:java-snapshot-testing-plugin-jackson:3.2.+'
 testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
 testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 
 // slf4j logging implementation if you don't already have one
 testImplementation("org.slf4j:slf4j-simple:2.0.0-alpha0")
+```
+
+Note that if you'll want Jackson to serialize Java 8 date/time types or Optionals you should also add the following dependencies
+```groovy
+testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
+testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 ```
 
 2. Create `snapshot.properties` and configure your global settings. Be sure to set `output-dir` appropriately for your
@@ -147,11 +151,12 @@ Plugins
 - [Jackson for JSON serialization](https://search.maven.org/search?q=a:java-snapshot-testing-plugin-jackson)
     - You need jackson on your classpath (Gradle example)
       ```groovy
-          // Required java-snapshot-testing peer dependencies
+         // Required java-snapshot-testing peer dependencies
          testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
          testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-         testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-         testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
+         // Optional java-snapshot-testing peer dependencies
+         testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
+         testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
       ```
 
 ## How does it work?

--- a/java-snapshot-testing-core/build.gradle
+++ b/java-snapshot-testing-core/build.gradle
@@ -4,8 +4,6 @@ dependencies {
 
     compileOnly 'com.fasterxml.jackson.core:jackson-core:2.11.3'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 
     implementation 'org.assertj:assertj-core:3.11.1'
     implementation 'org.opentest4j:opentest4j:1.2.0'

--- a/java-snapshot-testing-junit4/build.gradle
+++ b/java-snapshot-testing-junit4/build.gradle
@@ -16,8 +16,6 @@ dependencies {
     // Required java-snapshot-testing peer dependencies
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 }
 
 publishing {

--- a/java-snapshot-testing-junit5/build.gradle
+++ b/java-snapshot-testing-junit5/build.gradle
@@ -22,8 +22,6 @@ dependencies {
     testImplementation project(':java-snapshot-testing-plugin-jackson')
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 }
 
 test { useJUnitPlatform() }

--- a/java-snapshot-testing-plugin-jackson/build.gradle
+++ b/java-snapshot-testing-plugin-jackson/build.gradle
@@ -6,8 +6,6 @@ dependencies {
     // Client needs to supply their own versions
     compileOnly 'com.fasterxml.jackson.core:jackson-core:2.11.3'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    compileOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 
     // User supplied Junit5 version
     compileOnly 'org.junit.jupiter:junit-jupiter-api:5.3.2'
@@ -24,8 +22,8 @@ dependencies {
 
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
+    testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
+    testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 }
 
 test { useJUnitPlatform() }

--- a/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/serializers/JacksonSnapshotSerializer.java
+++ b/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/serializers/JacksonSnapshotSerializer.java
@@ -9,8 +9,6 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.Separators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public class JacksonSnapshotSerializer implements SnapshotSerializer {
 
@@ -42,8 +40,7 @@ public class JacksonSnapshotSerializer implements SnapshotSerializer {
     this.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
     this.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-    this.registerModule(new JavaTimeModule());
-    this.registerModule(new Jdk8Module());
+    this.findAndRegisterModules();
 
     this.setVisibility(
         this

--- a/java-snapshot-testing-spock/build.gradle
+++ b/java-snapshot-testing-spock/build.gradle
@@ -20,8 +20,6 @@ dependencies {
     // Required java-snapshot-testing peer dependencies
     testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
 }
 
 publishing {


### PR DESCRIPTION
Gave fixing https://github.com/origin-energy/java-snapshot-testing/issues/103 a shot.