### PR TITLE
Add keywords "overwriting" and "override" to help find the "update" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -784,9 +784,9 @@ public class JUnit5ResolutionHierarchyExample {
 }
 ```
 
-## Automatically updating a snapshot via `-PupdateSnapshot=filter`
+## Automatically overwriting snapshots via `-PupdateSnapshot=filter`
 
-Often - after analysing each snapshot and verifying it is correct, you will need to generate a new baseline for the
+Often - after analysing each snapshot and verifying it is correct, you will need to override the existing
 snapshots.
 
 Note that you may need to do some Gradle trickery to make this visible to your actual tests


### PR DESCRIPTION
I tried searching the README for an answer to my question in

- #131

but I was stuck on the keyword "override" and "overwrite". Now the section has those keywords, and it still has "update" too.