### PR TITLE
#141: Force BigDecimal serialization in non-scientific notation

### DIFF
--- a/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/JacksonSnapshotSerializer.java
+++ b/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/JacksonSnapshotSerializer.java
@@ -7,6 +7,7 @@ import au.com.origin.snapshots.serializers.SerializerType;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.PrettyPrinter;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
@@ -45,6 +46,7 @@ public class JacksonSnapshotSerializer implements SnapshotSerializer {
         {
           this.enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS);
           this.enable(SerializationFeature.WRITE_DATES_WITH_ZONE_ID);
+          this.enable(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN);
           this.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
           this.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
           this.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/jackson/serializers/JacksonSnapshotSerializerTest.java
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/jackson/serializers/JacksonSnapshotSerializerTest.java
@@ -5,6 +5,8 @@ import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.serializers.SerializerType;
 import au.com.origin.snapshots.serializers.SnapshotSerializer;
+
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -112,6 +114,10 @@ public class JacksonSnapshotSerializerTest {
     private final short aShort = 32767;
     private final int anInt = 2147483647;
     private final long aLong = 9223372036854775807L;
+    /**
+     * Note: Stripping trailing zeroes is required to force {@link BigDecimal#toString()} to use scientific notation.
+     */
+    private final BigDecimal aBigDecimal = BigDecimal.valueOf(100).stripTrailingZeros();
     private final float aFloat = 0.1234567F;
     private final double aDouble = 1.123456789123456D;
     private final boolean aBoolean = true;

--- a/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/jackson/serializers/__snapshots__/JacksonSnapshotSerializerTest.snap
+++ b/java-snapshot-testing-plugin-jackson/src/test/java/au/com/origin/snapshots/jackson/serializers/__snapshots__/JacksonSnapshotSerializerTest.snap
@@ -5,6 +5,7 @@ au.com.origin.snapshots.jackson.serializers.JacksonSnapshotSerializerTest.should
     "aShort": 32767,
     "anInt": 2147483647,
     "aLong": 9223372036854775807,
+    "aBigDecimal": 100,
     "aFloat": 0.1234567,
     "aDouble": 1.123456789123456,
     "aBoolean": true,


### PR DESCRIPTION
This implements the proposal discussed here: https://github.com/origin-energy/java-snapshot-testing/discussions/141

Converted to draft, as I'm not sure it's the best way to proceed. Will update the discussion.