### PR TITLE
It should be possible to skip `findAndRegisterModules` in JacksonSnapshotSerializer

### DIFF
--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
@@ -55,6 +55,5 @@ public class SnapshotHeaders {
       snapshotSerializerContext.getHeader().put("custom2", "anything2");
       return super.apply(object, snapshotSerializerContext);
     }
-  }
-  ;
+  };
 }

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
@@ -55,5 +55,6 @@ public class SnapshotHeaders {
       snapshotSerializerContext.getHeader().put("custom2", "anything2");
       return super.apply(object, snapshotSerializerContext);
     }
-  };
+  }
+  ;
 }

--- a/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/v1/JacksonSnapshotSerializer.java
+++ b/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/v1/JacksonSnapshotSerializer.java
@@ -49,7 +49,9 @@ public class JacksonSnapshotSerializer implements SnapshotSerializer {
           this.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
           this.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
-          this.findAndRegisterModules();
+          if (shouldFindAndRegisterModules()) {
+            this.findAndRegisterModules();
+          }
 
           this.setVisibility(
               this.getSerializationConfig()
@@ -68,6 +70,14 @@ public class JacksonSnapshotSerializer implements SnapshotSerializer {
    * @param objectMapper existing ObjectMapper
    */
   public void configure(ObjectMapper objectMapper) {}
+
+  /**
+   * Override to control the registration of all available jackson modules within the classpath
+   * which are locatable via JDK ServiceLoader facility, along with module-provided SPI.
+   */
+  protected boolean shouldFindAndRegisterModules() {
+    return true;
+  }
 
   @Override
   public Snapshot apply(Object object, SnapshotSerializerContext gen) {


### PR DESCRIPTION
Currently `ObjectMapper#findAndRegisterModules` is not skipable by a subclass of `JacksonSnapshotSerializer`. This means all Modules in the classpath which supports registering via service loader will be registered. This is not always what is needed, like in our case:

We use in our porject production code Afterburner (if JRE is <= 8) and Blackbird (if JRE is > 8). We have a switch when our ObjectMapper is configured, like this: 
```java
        if (SystemUtils.isJavaVersionAtMost(JavaVersion.JAVA_1_8)) {
            log.info("Use Afterburner in Java 8 environment");
            objectMapper.registerModule(new AfterburnerModule());
        } else {
            log.info("Use Blackbird in Java 9+ environment");
            objectMapper.registerModule(new BlackbirdModule());
        }
```

With this change a subclass of `JacksonSnapshotSerializer` can decide in its `configure` override if  `ObjectMapper#findAndRegisterModules` should be executed (just call `super`) or if (like in our case) the impl should register needed modules manually (don't call `super`).