### PR TITLE
#patch: enable snapshot-testing in the super class.

### DIFF
--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/ExtendsSnapshotTestBaseTest.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/ExtendsSnapshotTestBaseTest.java
@@ -1,0 +1,10 @@
+package au.com.origin.snapshots;
+
+import org.junit.jupiter.api.Test;
+
+public class ExtendsSnapshotTestBaseTest extends SnapshotTestBase {
+  @Test
+  void test() {
+    snapshot("OK");
+  }
+}

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/SnapshotTestBase.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/SnapshotTestBase.java
@@ -1,0 +1,13 @@
+package au.com.origin.snapshots;
+
+import au.com.origin.snapshots.junit5.SnapshotExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({SnapshotExtension.class})
+public class SnapshotTestBase {
+  protected Expect expect;
+
+  protected void snapshot(Object value) {
+    expect.toMatchSnapshot(value);
+  }
+}

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/ExtendsSnapshotTestBaseTest.snap
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/ExtendsSnapshotTestBaseTest.snap
@@ -1,0 +1,3 @@
+au.com.origin.snapshots.ExtendsSnapshotTestBaseTest.test=[
+OK
+]


### PR DESCRIPTION
SnapshotExtension is specified in the base class so that Except can be injected.

```
@ExtendWith({SnapshotExtension.class})
public class SnapshotTestBase {
  protected Expect expect;

  protected void snapshot(Object value) {
    expect.toMatchSnapshot(value);
  }
}
```
