### PR TITLE
Enable snapshot-testing in base class

### DIFF
--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/ReflectionUtils.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/ReflectionUtils.java
@@ -1,48 +1,48 @@
 package au.com.origin.snapshots;
 
-import lombok.experimental.UtilityClass;
-
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Optional;
 import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class ReflectionUtils {
 
-    /**
-     * Find {@link Field} by given predicate.
-     * <p>
-     * Invoke the given predicate on all fields in the target class, going up the class hierarchy to get all declared fields.
-     *
-     * @param clazz     the target class to analyze
-     * @param predicate the predicate
-     * @return the field or empty optional
-     */
-    public static Optional<Field> findFieldByPredicate(final Class<?> clazz, final Predicate<Field> predicate) {
-        Class<?> targetClass = clazz;
+  /**
+   * Find {@link Field} by given predicate.
+   *
+   * <p>Invoke the given predicate on all fields in the target class, going up the class hierarchy
+   * to get all declared fields.
+   *
+   * @param clazz the target class to analyze
+   * @param predicate the predicate
+   * @return the field or empty optional
+   */
+  public static Optional<Field> findFieldByPredicate(
+      final Class<?> clazz, final Predicate<Field> predicate) {
+    Class<?> targetClass = clazz;
 
-        do {
-            final Field[] fields = targetClass.getDeclaredFields();
-            for (final Field field : fields) {
-                if (!predicate.test(field)) {
-                    continue;
-                }
-                return Optional.of(field);
-            }
-            targetClass = targetClass.getSuperclass();
+    do {
+      final Field[] fields = targetClass.getDeclaredFields();
+      for (final Field field : fields) {
+        if (!predicate.test(field)) {
+          continue;
         }
-        while (targetClass != null && targetClass != Object.class);
+        return Optional.of(field);
+      }
+      targetClass = targetClass.getSuperclass();
+    } while (targetClass != null && targetClass != Object.class);
 
-        return Optional.empty();
+    return Optional.empty();
+  }
+
+  public static void makeAccessible(final Field field) {
+    if ((!Modifier.isPublic(field.getModifiers())
+            || !Modifier.isPublic(field.getDeclaringClass().getModifiers())
+            || Modifier.isFinal(field.getModifiers()))
+        && !field.isAccessible()) {
+      field.setAccessible(true);
     }
-
-    public static void makeAccessible(final Field field) {
-        if ((!Modifier.isPublic(field.getModifiers()) ||
-            !Modifier.isPublic(field.getDeclaringClass().getModifiers()) ||
-            Modifier.isFinal(field.getModifiers())) && !field.isAccessible()) {
-            field.setAccessible(true);
-        }
-    }
-
+  }
 }

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/ReflectionUtils.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/ReflectionUtils.java
@@ -1,0 +1,48 @@
+package au.com.origin.snapshots;
+
+import lombok.experimental.UtilityClass;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+@UtilityClass
+public class ReflectionUtils {
+
+    /**
+     * Find {@link Field} by given predicate.
+     * <p>
+     * Invoke the given predicate on all fields in the target class, going up the class hierarchy to get all declared fields.
+     *
+     * @param clazz     the target class to analyze
+     * @param predicate the predicate
+     * @return the field or empty optional
+     */
+    public static Optional<Field> findFieldByPredicate(final Class<?> clazz, final Predicate<Field> predicate) {
+        Class<?> targetClass = clazz;
+
+        do {
+            final Field[] fields = targetClass.getDeclaredFields();
+            for (final Field field : fields) {
+                if (!predicate.test(field)) {
+                    continue;
+                }
+                return Optional.of(field);
+            }
+            targetClass = targetClass.getSuperclass();
+        }
+        while (targetClass != null && targetClass != Object.class);
+
+        return Optional.empty();
+    }
+
+    public static void makeAccessible(final Field field) {
+        if ((!Modifier.isPublic(field.getModifiers()) ||
+            !Modifier.isPublic(field.getDeclaringClass().getModifiers()) ||
+            Modifier.isFinal(field.getModifiers())) && !field.isAccessible()) {
+            field.setAccessible(true);
+        }
+    }
+
+}

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/utils/ReflectionUtils.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/utils/ReflectionUtils.java
@@ -1,4 +1,4 @@
-package au.com.origin.snapshots;
+package au.com.origin.snapshots.utils;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotHeaders.java
@@ -55,5 +55,5 @@ public class SnapshotHeaders {
       snapshotSerializerContext.getHeader().put("custom2", "anything2");
       return super.apply(object, snapshotSerializerContext);
     }
-  };
+  }
 }

--- a/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
+++ b/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
@@ -14,19 +14,17 @@ class SharedSnapshotHelpers implements SnapshotConfigInjector {
 
   public void injectExpectInstanceVariable(
       SnapshotVerifier snapshotVerifier, Method testMethod, Object testInstance) {
-    Arrays.stream(testInstance.getClass().getDeclaredFields())
-        .filter(it -> it.getType() == Expect.class)
-        .findFirst()
-        .ifPresent(
-            field -> {
+
+      ReflectionUtils.findFieldByPredicate(testInstance.getClass(), (field) -> field.getType() == Expect.class)
+          .ifPresent((field) -> {
               Expect expect = Expect.of(snapshotVerifier, testMethod);
-              field.setAccessible(true);
+              ReflectionUtils.makeAccessible(field);
               try {
-                field.set(testInstance, expect);
+                  field.set(testInstance, expect);
               } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
+                  throw new RuntimeException(e);
               }
-            });
+          });
   }
 
   public Statement injectExpectMethodArgument(

--- a/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
+++ b/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
@@ -15,16 +15,18 @@ class SharedSnapshotHelpers implements SnapshotConfigInjector {
   public void injectExpectInstanceVariable(
       SnapshotVerifier snapshotVerifier, Method testMethod, Object testInstance) {
 
-      ReflectionUtils.findFieldByPredicate(testInstance.getClass(), (field) -> field.getType() == Expect.class)
-          .ifPresent((field) -> {
+    ReflectionUtils.findFieldByPredicate(
+            testInstance.getClass(), (field) -> field.getType() == Expect.class)
+        .ifPresent(
+            (field) -> {
               Expect expect = Expect.of(snapshotVerifier, testMethod);
               ReflectionUtils.makeAccessible(field);
               try {
-                  field.set(testInstance, expect);
+                field.set(testInstance, expect);
               } catch (IllegalAccessException e) {
-                  throw new RuntimeException(e);
+                throw new RuntimeException(e);
               }
-          });
+            });
   }
 
   public Statement injectExpectMethodArgument(

--- a/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
+++ b/java-snapshot-testing-junit4/src/main/java/au/com/origin/snapshots/junit4/SharedSnapshotHelpers.java
@@ -4,6 +4,7 @@ import au.com.origin.snapshots.*;
 import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.config.SnapshotConfigInjector;
+import au.com.origin.snapshots.utils.ReflectionUtils;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import org.junit.runner.Description;

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/BaseClassTest.java
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/BaseClassTest.java
@@ -1,0 +1,24 @@
+package au.com.origin.snapshots;
+
+import au.com.origin.snapshots.junit4.SnapshotRunner;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+@RunWith(Enclosed.class)
+public class BaseClassTest {
+
+    static class TestBase {
+        Expect expect;
+    }
+
+    @RunWith(SnapshotRunner.class)
+    public static class NestedClass extends TestBase {
+
+        @Test
+        public void helloWorldTest() {
+            expect.toMatchSnapshot("Hello World");
+        }
+    }
+
+}

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/BaseClassTest.java
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/BaseClassTest.java
@@ -8,17 +8,16 @@ import org.junit.runner.RunWith;
 @RunWith(Enclosed.class)
 public class BaseClassTest {
 
-    static class TestBase {
-        Expect expect;
+  static class TestBase {
+    Expect expect;
+  }
+
+  @RunWith(SnapshotRunner.class)
+  public static class NestedClass extends TestBase {
+
+    @Test
+    public void helloWorldTest() {
+      expect.toMatchSnapshot("Hello World");
     }
-
-    @RunWith(SnapshotRunner.class)
-    public static class NestedClass extends TestBase {
-
-        @Test
-        public void helloWorldTest() {
-            expect.toMatchSnapshot("Hello World");
-        }
-    }
-
+  }
 }

--- a/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/BaseClassTest$NestedClass.snap
+++ b/java-snapshot-testing-junit4/src/test/java/au/com/origin/snapshots/__snapshots__/BaseClassTest$NestedClass.snap
@@ -1,0 +1,3 @@
+au.com.origin.snapshots.BaseClassTest$NestedClass.helloWorldTest=[
+Hello World
+]

--- a/java-snapshot-testing-junit5/src/main/java/au/com/origin/snapshots/junit5/SnapshotExtension.java
+++ b/java-snapshot-testing-junit5/src/main/java/au/com/origin/snapshots/junit5/SnapshotExtension.java
@@ -1,13 +1,13 @@
 package au.com.origin.snapshots.junit5;
 
 import au.com.origin.snapshots.Expect;
-import au.com.origin.snapshots.ReflectionUtils;
 import au.com.origin.snapshots.SnapshotVerifier;
 import au.com.origin.snapshots.config.PropertyResolvingSnapshotConfig;
 import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.config.SnapshotConfigInjector;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import au.com.origin.snapshots.logging.LoggingHelper;
+import au.com.origin.snapshots.utils.ReflectionUtils;
 import java.lang.reflect.Field;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;

--- a/java-snapshot-testing-junit5/src/main/java/au/com/origin/snapshots/junit5/SnapshotExtension.java
+++ b/java-snapshot-testing-junit5/src/main/java/au/com/origin/snapshots/junit5/SnapshotExtension.java
@@ -8,6 +8,7 @@ import au.com.origin.snapshots.config.SnapshotConfig;
 import au.com.origin.snapshots.config.SnapshotConfigInjector;
 import au.com.origin.snapshots.exceptions.SnapshotMatchException;
 import au.com.origin.snapshots.logging.LoggingHelper;
+import java.lang.reflect.Field;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -18,8 +19,6 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
-
-import java.lang.reflect.Field;
 
 @Slf4j
 public class SnapshotExtension
@@ -111,16 +110,18 @@ public class SnapshotExtension
   @Override
   public void beforeEach(ExtensionContext context) {
     if (context.getTestInstance().isPresent() && context.getTestMethod().isPresent()) {
-      ReflectionUtils.findFieldByPredicate(context.getTestClass().get(), (field) -> field.getType() == Expect.class)
-        .ifPresent((field) -> {
-            Expect expect = Expect.of(snapshotVerifier, context.getTestMethod().get());
-            ReflectionUtils.makeAccessible(field);
-            try {
-                field.set(context.getTestInstance().get(), expect);
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-        });
+      ReflectionUtils.findFieldByPredicate(
+              context.getTestClass().get(), (field) -> field.getType() == Expect.class)
+          .ifPresent(
+              (field) -> {
+                Expect expect = Expect.of(snapshotVerifier, context.getTestMethod().get());
+                ReflectionUtils.makeAccessible(field);
+                try {
+                  field.set(context.getTestInstance().get(), expect);
+                } catch (IllegalAccessException e) {
+                  throw new RuntimeException(e);
+                }
+              });
     }
   }
 }

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/BaseClassTest.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/BaseClassTest.java
@@ -8,18 +8,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith({SnapshotExtension.class})
 public class BaseClassTest {
 
-    class TestBase {
-        Expect expect;
+  class TestBase {
+    Expect expect;
+  }
+
+  @Nested
+  @ExtendWith(SnapshotExtension.class)
+  class NestedClass extends TestBase {
+
+    @Test
+    public void helloWorldTest() {
+      expect.toMatchSnapshot("Hello World");
     }
-
-    @Nested
-    @ExtendWith(SnapshotExtension.class)
-    class NestedClass extends TestBase {
-
-        @Test
-        public void helloWorldTest() {
-            expect.toMatchSnapshot("Hello World");
-        }
-    }
-
+  }
 }

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/BaseClassTest.java
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/BaseClassTest.java
@@ -1,0 +1,25 @@
+package au.com.origin.snapshots;
+
+import au.com.origin.snapshots.junit5.SnapshotExtension;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({SnapshotExtension.class})
+public class BaseClassTest {
+
+    class TestBase {
+        Expect expect;
+    }
+
+    @Nested
+    @ExtendWith(SnapshotExtension.class)
+    class NestedClass extends TestBase {
+
+        @Test
+        public void helloWorldTest() {
+            expect.toMatchSnapshot("Hello World");
+        }
+    }
+
+}

--- a/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/BaseClassTest$NestedClass.snap
+++ b/java-snapshot-testing-junit5/src/test/java/au/com/origin/snapshots/__snapshots__/BaseClassTest$NestedClass.snap
@@ -1,0 +1,3 @@
+au.com.origin.snapshots.BaseClassTest$NestedClass.helloWorldTest=[
+Hello World
+]

--- a/java-snapshot-testing-spock/src/main/groovy/au/com/origin/snapshots/spock/SnapshotMethodInterceptor.groovy
+++ b/java-snapshot-testing-spock/src/main/groovy/au/com/origin/snapshots/spock/SnapshotMethodInterceptor.groovy
@@ -1,7 +1,7 @@
 package au.com.origin.snapshots.spock
 
 import au.com.origin.snapshots.Expect
-import au.com.origin.snapshots.ReflectionUtils
+import au.com.origin.snapshots.utils.ReflectionUtils
 import au.com.origin.snapshots.SnapshotVerifier
 import au.com.origin.snapshots.logging.LoggingHelper
 import org.slf4j.LoggerFactory

--- a/java-snapshot-testing-spock/src/main/groovy/au/com/origin/snapshots/spock/SnapshotMethodInterceptor.groovy
+++ b/java-snapshot-testing-spock/src/main/groovy/au/com/origin/snapshots/spock/SnapshotMethodInterceptor.groovy
@@ -1,12 +1,11 @@
 package au.com.origin.snapshots.spock
 
 import au.com.origin.snapshots.Expect
+import au.com.origin.snapshots.ReflectionUtils
 import au.com.origin.snapshots.SnapshotVerifier
 import au.com.origin.snapshots.logging.LoggingHelper
-import lombok.extern.slf4j.Slf4j
 import org.slf4j.LoggerFactory
 import org.spockframework.runtime.extension.AbstractMethodInterceptor
-import org.spockframework.runtime.extension.IMethodInterceptor
 import org.spockframework.runtime.extension.IMethodInvocation
 
 import java.lang.reflect.Method
@@ -40,13 +39,16 @@ class SnapshotMethodInterceptor extends AbstractMethodInterceptor {
     }
 
     private void updateInstanceVariable(Object testInstance, Method testMethod) {
-        testInstance.class.declaredFields
-            .find { it.getType() == Expect.class }
-            ?.with {
-                Expect expect = Expect.of(snapshotVerifier, testMethod)
-                it.setAccessible(true)
-                it.set(testInstance, expect)
-            }
+        ReflectionUtils.findFieldByPredicate(testInstance.class, { field -> field.getType() == Expect.class })
+            .ifPresent({ field ->
+                Expect expect = Expect.of(snapshotVerifier, testMethod);
+                ReflectionUtils.makeAccessible(field);
+                try {
+                    field.set(testInstance, expect);
+                } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            });
     }
 
     @Override

--- a/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/SpecificationBase.groovy
+++ b/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/SpecificationBase.groovy
@@ -1,0 +1,10 @@
+package au.com.origin.snapshots
+
+import org.junit.runner.RunWith
+import org.spockframework.runtime.Sputnik
+import spock.lang.Specification
+
+@RunWith(Sputnik.class)
+class SpecificationBase extends Specification {
+    Expect expect;
+}

--- a/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/TestBaseSpec.groovy
+++ b/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/TestBaseSpec.groovy
@@ -1,0 +1,18 @@
+package au.com.origin.snapshots
+
+import au.com.origin.snapshots.annotations.SnapshotName
+import au.com.origin.snapshots.spock.EnableSnapshots
+
+@EnableSnapshots
+class TestBaseSpec extends SpecificationBase {
+
+    @SnapshotName("Should use extension")
+    def "Should use extension"() {
+        when:
+        expect.toMatchSnapshot("Hello World")
+
+        then:
+        true
+    }
+
+}

--- a/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/__snapshots__/TestBaseSpec.snap
+++ b/java-snapshot-testing-spock/src/test/groovy/au/com/origin/snapshots/__snapshots__/TestBaseSpec.snap
@@ -1,0 +1,3 @@
+Should use extension=[
+Hello World
+]


### PR DESCRIPTION
Re-iteration of https://github.com/origin-energy/java-snapshot-testing/pull/153 with support for JUnit4 and Spock.

```
@ExtendWith({SnapshotExtension.class})
public class SnapshotTestBase {
  protected Expect expect;

  protected void snapshot(Object value) {
    expect.toMatchSnapshot(value);
  }
}
```