### PR TITLE
Restore JSON formatting with Jackson 2.16

### DIFF
--- a/java-snapshot-testing-plugin-jackson/build.gradle
+++ b/java-snapshot-testing-plugin-jackson/build.gradle
@@ -21,10 +21,10 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.11.1'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0' // For docs/ reporter example
 
-    testImplementation 'com.fasterxml.jackson.core:jackson-core:2.11.3'
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.11.3'
-    testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.11.3'
-    testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.11.3'
+    testImplementation 'com.fasterxml.jackson.core:jackson-core:2.16.0'
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.16.0'
+    testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.16.0'
+    testRuntimeOnly 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.16.0'
 }
 
 test { useJUnitPlatform() }

--- a/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/v1/JacksonSnapshotSerializer.java
+++ b/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/v1/JacksonSnapshotSerializer.java
@@ -8,9 +8,6 @@ import au.com.origin.snapshots.serializers.SnapshotSerializer;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.PrettyPrinter;
-import com.fasterxml.jackson.core.util.DefaultIndenter;
-import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
-import com.fasterxml.jackson.core.util.Separators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import java.util.Arrays;
@@ -18,28 +15,7 @@ import java.util.List;
 
 public class JacksonSnapshotSerializer implements SnapshotSerializer {
 
-  private final PrettyPrinter pp =
-      new DefaultPrettyPrinter("") {
-        {
-          Indenter lfOnlyIndenter = new DefaultIndenter("  ", "\n");
-          this.indentArraysWith(lfOnlyIndenter);
-          this.indentObjectsWith(lfOnlyIndenter);
-        }
-
-        // It's a requirement
-        // @see https://github.com/FasterXML/jackson-databind/issues/2203
-        public DefaultPrettyPrinter createInstance() {
-          return new DefaultPrettyPrinter(this);
-        }
-
-        @Override
-        public DefaultPrettyPrinter withSeparators(Separators separators) {
-          this._separators = separators;
-          this._objectFieldValueSeparatorWithSpaces =
-              separators.getObjectFieldValueSeparator() + " ";
-          return this;
-        }
-      };
+  private final PrettyPrinter pp = new SnapshotPrettyPrinter();
   private final ObjectMapper objectMapper =
       new ObjectMapper() {
         {

--- a/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/v1/SnapshotPrettyPrinter.java
+++ b/java-snapshot-testing-plugin-jackson/src/main/java/au/com/origin/snapshots/jackson/serializers/v1/SnapshotPrettyPrinter.java
@@ -1,0 +1,23 @@
+package au.com.origin.snapshots.jackson.serializers.v1;
+
+import com.fasterxml.jackson.core.util.DefaultIndenter;
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+
+class SnapshotPrettyPrinter extends DefaultPrettyPrinter {
+
+  public SnapshotPrettyPrinter() {
+    super("");
+    Indenter lfOnlyIndenter = new DefaultIndenter("  ", "\n");
+    this.indentArraysWith(lfOnlyIndenter);
+    this.indentObjectsWith(lfOnlyIndenter);
+
+    this._objectFieldValueSeparatorWithSpaces =
+        this._separators.getObjectFieldValueSeparator() + " ";
+  }
+
+  // It's a requirement
+  // @see https://github.com/FasterXML/jackson-databind/issues/2203
+  public DefaultPrettyPrinter createInstance() {
+    return new DefaultPrettyPrinter(this);
+  }
+}


### PR DESCRIPTION
This is a fix for #162 and works by utilizing the formatting features introduced in Jackson 2.16 instead of overwriting Jackson internals. Obviously, this makes it incompatible with Jackson versions older then 2.16.0...