### PR TITLE
Issue with Snapshot.parse regex - ERROR: Found orphan snapshots

### DIFF
--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Snapshot.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Snapshot.java
@@ -29,7 +29,8 @@ public class Snapshot implements Comparable<Snapshot> {
   }
 
   public static Snapshot parse(String rawText) {
-    String regex = "^(?<name>.*?)(\\[(?<scenario>[^]]*)])?=(?<header>\\{[^}]*?})?(?<snapshot>(.*)$)";
+    String regex =
+        "^(?<name>.*?)(\\[(?<scenario>[^]]*)])?=(?<header>\\{[^}]*?})?(?<snapshot>(.*)$)";
     Pattern p = Pattern.compile(regex, Pattern.DOTALL);
     Matcher m = p.matcher(rawText);
     boolean found = m.find();

--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Snapshot.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/Snapshot.java
@@ -29,7 +29,7 @@ public class Snapshot implements Comparable<Snapshot> {
   }
 
   public static Snapshot parse(String rawText) {
-    String regex = "^(?<name>.*?)(\\[(?<scenario>.*)\\])?=(?<header>\\{.*?\\})?(?<snapshot>(.*)$)";
+    String regex = "^(?<name>.*?)(\\[(?<scenario>[^]]*)])?=(?<header>\\{[^}]*?})?(?<snapshot>(.*)$)";
     Pattern p = Pattern.compile(regex, Pattern.DOTALL);
     Matcher m = p.matcher(rawText);
     boolean found = m.find();

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
@@ -1,0 +1,100 @@
+package au.com.origin.snapshots;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+class SnapshotTest {
+
+    /*
+     name[scenario]={
+        "header-key": "header-value"
+      }body
+     */
+
+    @Test
+    public void shouldParseSnapshot() {
+        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+                .name("au.com.origin.snapshots.Test")
+                .body("body")
+                .build()
+                .raw()
+        );
+        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getHeader()).isEmpty();
+        assertThat(snapshot.getScenario()).isBlank();
+        assertThat(snapshot.getBody()).isEqualTo("body");
+    }
+
+    @Test
+    public void shouldParseSnapshotWithHeaders() {
+        SnapshotHeader header = new SnapshotHeader();
+        header.put("header1", "value1");
+        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+                .name("au.com.origin.snapshots.Test")
+                .header(header)
+                .body("body")
+                .build()
+                .raw()
+        );
+        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getHeader()).containsExactly(entry("header1", "value1"));
+        assertThat(snapshot.getScenario()).isBlank();
+        assertThat(snapshot.getBody()).isEqualTo("body");
+    }
+
+    @Test
+    public void shouldParseSnapshotWithScenario() {
+        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+                .name("au.com.origin.snapshots.Test")
+                .scenario("scenario")
+                .body("body")
+                .build()
+                .raw()
+        );
+        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
+        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getHeader()).isEmpty();
+        assertThat(snapshot.getScenario()).isEqualTo("scenario");
+        assertThat(snapshot.getBody()).isEqualTo("body");
+    }
+
+    @Test
+    public void shouldParseSnapshotWithScenarioAndHeaders() {
+        SnapshotHeader header = new SnapshotHeader();
+        header.put("header1", "value1");
+        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+                .name("au.com.origin.snapshots.Test")
+                .scenario("scenario")
+                .header(header)
+                .body("body")
+                .build()
+                .raw()
+        );
+        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
+        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getHeader()).containsExactly(entry("header1", "value1"));
+        assertThat(snapshot.getScenario()).isEqualTo("scenario");
+        assertThat(snapshot.getBody()).isEqualTo("body");
+    }
+
+    @Test
+    public void shouldParseSnapshotWithScenarioAndBodyWithSomethingSimilarToAnScenarioToConfuseRegex() {
+        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+                .name("au.com.origin.snapshots.Test")
+                .scenario("scenario")
+                .body("[xxx]=yyy")
+                .build()
+                .raw()
+        );
+        System.out.println(snapshot.raw());
+        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
+        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+        assertThat(snapshot.getHeader()).isEmpty();
+        assertThat(snapshot.getScenario()).isEqualTo("scenario");
+        assertThat(snapshot.getBody()).isEqualTo("[xxx]=yyy");
+    }
+}

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
@@ -86,7 +86,6 @@ class SnapshotTest {
                 .body("[xxx]=yyy")
                 .build()
                 .raw());
-    System.out.println(snapshot.raw());
     assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
     assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
     assertThat(snapshot.getHeader()).isEmpty();

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
@@ -7,12 +7,6 @@ import static org.assertj.core.api.Assertions.entry;
 
 class SnapshotTest {
 
-    /*
-     name[scenario]={
-        "header-key": "header-value"
-      }body
-     */
-
     @Test
     public void shouldParseSnapshot() {
         Snapshot snapshot = Snapshot.parse(Snapshot.builder()

--- a/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
+++ b/java-snapshot-testing-core/src/test/java/au/com/origin/snapshots/SnapshotTest.java
@@ -1,94 +1,96 @@
 package au.com.origin.snapshots;
 
-import org.junit.jupiter.api.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import org.junit.jupiter.api.Test;
+
 class SnapshotTest {
 
-    @Test
-    public void shouldParseSnapshot() {
-        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
-                .name("au.com.origin.snapshots.Test")
-                .body("body")
-                .build()
-                .raw()
-        );
-        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getHeader()).isEmpty();
-        assertThat(snapshot.getScenario()).isBlank();
-        assertThat(snapshot.getBody()).isEqualTo("body");
-    }
+  @Test
+  public void shouldParseSnapshot() {
+    Snapshot snapshot =
+        Snapshot.parse(
+            Snapshot.builder().name("au.com.origin.snapshots.Test").body("body").build().raw());
+    assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getHeader()).isEmpty();
+    assertThat(snapshot.getScenario()).isBlank();
+    assertThat(snapshot.getBody()).isEqualTo("body");
+  }
 
-    @Test
-    public void shouldParseSnapshotWithHeaders() {
-        SnapshotHeader header = new SnapshotHeader();
-        header.put("header1", "value1");
-        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+  @Test
+  public void shouldParseSnapshotWithHeaders() {
+    SnapshotHeader header = new SnapshotHeader();
+    header.put("header1", "value1");
+    Snapshot snapshot =
+        Snapshot.parse(
+            Snapshot.builder()
                 .name("au.com.origin.snapshots.Test")
                 .header(header)
                 .body("body")
                 .build()
-                .raw()
-        );
-        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getHeader()).containsExactly(entry("header1", "value1"));
-        assertThat(snapshot.getScenario()).isBlank();
-        assertThat(snapshot.getBody()).isEqualTo("body");
-    }
+                .raw());
+    assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getHeader()).containsExactly(entry("header1", "value1"));
+    assertThat(snapshot.getScenario()).isBlank();
+    assertThat(snapshot.getBody()).isEqualTo("body");
+  }
 
-    @Test
-    public void shouldParseSnapshotWithScenario() {
-        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+  @Test
+  public void shouldParseSnapshotWithScenario() {
+    Snapshot snapshot =
+        Snapshot.parse(
+            Snapshot.builder()
                 .name("au.com.origin.snapshots.Test")
                 .scenario("scenario")
                 .body("body")
                 .build()
-                .raw()
-        );
-        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
-        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getHeader()).isEmpty();
-        assertThat(snapshot.getScenario()).isEqualTo("scenario");
-        assertThat(snapshot.getBody()).isEqualTo("body");
-    }
+                .raw());
+    assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
+    assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getHeader()).isEmpty();
+    assertThat(snapshot.getScenario()).isEqualTo("scenario");
+    assertThat(snapshot.getBody()).isEqualTo("body");
+  }
 
-    @Test
-    public void shouldParseSnapshotWithScenarioAndHeaders() {
-        SnapshotHeader header = new SnapshotHeader();
-        header.put("header1", "value1");
-        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+  @Test
+  public void shouldParseSnapshotWithScenarioAndHeaders() {
+    SnapshotHeader header = new SnapshotHeader();
+    header.put("header1", "value1");
+    Snapshot snapshot =
+        Snapshot.parse(
+            Snapshot.builder()
                 .name("au.com.origin.snapshots.Test")
                 .scenario("scenario")
                 .header(header)
                 .body("body")
                 .build()
-                .raw()
-        );
-        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
-        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getHeader()).containsExactly(entry("header1", "value1"));
-        assertThat(snapshot.getScenario()).isEqualTo("scenario");
-        assertThat(snapshot.getBody()).isEqualTo("body");
-    }
+                .raw());
+    assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
+    assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getHeader()).containsExactly(entry("header1", "value1"));
+    assertThat(snapshot.getScenario()).isEqualTo("scenario");
+    assertThat(snapshot.getBody()).isEqualTo("body");
+  }
 
-    @Test
-    public void shouldParseSnapshotWithScenarioAndBodyWithSomethingSimilarToAnScenarioToConfuseRegex() {
-        Snapshot snapshot = Snapshot.parse(Snapshot.builder()
+  @Test
+  public void
+      shouldParseSnapshotWithScenarioAndBodyWithSomethingSimilarToAnScenarioToConfuseRegex() {
+    Snapshot snapshot =
+        Snapshot.parse(
+            Snapshot.builder()
                 .name("au.com.origin.snapshots.Test")
                 .scenario("scenario")
                 .body("[xxx]=yyy")
                 .build()
-                .raw()
-        );
-        System.out.println(snapshot.raw());
-        assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
-        assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
-        assertThat(snapshot.getHeader()).isEmpty();
-        assertThat(snapshot.getScenario()).isEqualTo("scenario");
-        assertThat(snapshot.getBody()).isEqualTo("[xxx]=yyy");
-    }
+                .raw());
+    System.out.println(snapshot.raw());
+    assertThat(snapshot.getIdentifier()).isEqualTo("au.com.origin.snapshots.Test[scenario]");
+    assertThat(snapshot.getName()).isEqualTo("au.com.origin.snapshots.Test");
+    assertThat(snapshot.getHeader()).isEmpty();
+    assertThat(snapshot.getScenario()).isEqualTo("scenario");
+    assertThat(snapshot.getBody()).isEqualTo("[xxx]=yyy");
+  }
 }


### PR DESCRIPTION
Having a snapshot with a scenario and a body that contains something similar to `[xxx]=yyy` makes the `Snapshot.parse` regex fail, resulting in tests failing due to `ERROR: Found orphan snapshots`

Issue https://github.com/origin-energy/java-snapshot-testing/issues/178

Test `shouldParseSnapshotWithScenarioAndBodyWithSomethingSimilarToAnScenarioToConfuseRegex` will fail, one possible solution is to change the regex in `Snapshot.parse`:

from:
```java
String regex = "^(?<name>.*?)(\\[(?<scenario>.*)\\])?=(?<header>\\{.*?\\})?(?<snapshot>(.*)$)";
```

to:
```java
String regex = "^(?<name>.*?)(\\[(?<scenario>[^]]*)])?=(?<header>\\{[^}]*?})?(?<snapshot>(.*)$)";
```

See commit [Improve regex](https://github.com/origin-energy/java-snapshot-testing/pull/177/commits/f234cc83a33850c284f068dc09b4ce7eeab72346) and note the `[^]]*` in `scenario` group and `[^}]*` in `header` group, instead of just `.*`