### PR TITLE
Made SnapshotFile constructor public to allow for defining the name of the snapshot file

### DIFF
--- a/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotFile.java
+++ b/java-snapshot-testing-core/src/main/java/au/com/origin/snapshots/SnapshotFile.java
@@ -32,7 +32,7 @@ public class SnapshotFile {
   @Getter private Set<Snapshot> snapshots = Collections.synchronizedSortedSet(new TreeSet<>());
   private Set<Snapshot> debugSnapshots = Collections.synchronizedSortedSet(new TreeSet<>());
 
-  SnapshotFile(String srcDirPath, String fileName, Class<?> testClass) throws IOException {
+  public SnapshotFile(String srcDirPath, String fileName, Class<?> testClass) throws IOException {
     this.testClass = testClass;
     this.fileName = srcDirPath + File.separator + fileName;
     log.info("Snapshot File: " + this.fileName);


### PR DESCRIPTION
I am trying to generate snapshots as part of Cucumber scenario executions. However, Cucumber scenarios and features are *not* classes, so every snapshot for every scenario gets lumped into a single `.snap` file. By making the constructor of `SnapshotFile` public, I can make the library create one `.snap` file per feature file.